### PR TITLE
Restore date-preserving watcher interval API

### DIFF
--- a/tyrian/src-js/tyrian/syntax.scala
+++ b/tyrian/src-js/tyrian/syntax.scala
@@ -50,29 +50,37 @@ object syntax:
     def timeout(duration: Seconds, msg: GlobalMsg): Watcher =
       timeout(duration.toMillis, msg, "[tyrian-watcher-timeout] " + duration.toMillis.toString + msg.toString)
 
-    /** Creates a watcher that repeatedly emits messages at regular intervals. */
-    def every(interval: Millis, id: String, toMsg: Millis => GlobalMsg): Watcher =
-      Watcher.fromSub {
-        val f: js.Date => GlobalMsg =
-          dt => toMsg(Millis(dt.getTime().toLong))
-
+    /** Creates a watcher that repeatedly emits the current date at regular intervals. */
+    def fromDate(interval: Millis, id: String, toMsg: js.Date => GlobalMsg): Watcher =
+      Watcher.fromSub(
         SubJsOps
           .every[IO](FiniteDuration(interval.toLong, TimeUnit.MILLISECONDS), id)
-          .map(f)
-      }
+          .map(toMsg)
+      )
+
+    /** Creates a watcher that repeatedly emits the current date at regular intervals. */
+    def fromDate(interval: Seconds, id: String, toMsg: js.Date => GlobalMsg): Watcher =
+      Watcher.fromSub(
+        SubJsOps
+          .every[IO](FiniteDuration(interval.toMillis.toLong, TimeUnit.MILLISECONDS), id)
+          .map(toMsg)
+      )
+
+    /** Creates a watcher that repeatedly emits the current date at regular intervals. */
+    def fromDate(interval: Millis, toMsg: js.Date => GlobalMsg): Watcher =
+      fromDate(interval, "[tyrian-watcher-from-date] " + interval.toString, toMsg)
+
+    /** Creates a watcher that repeatedly emits the current date at regular intervals. */
+    def fromDate(interval: Seconds, toMsg: js.Date => GlobalMsg): Watcher =
+      fromDate(interval, "[tyrian-watcher-from-date] " + interval.toMillis.toString, toMsg)
+
+    /** Creates a watcher that repeatedly emits messages at regular intervals. */
+    def every(interval: Millis, id: String, toMsg: Millis => GlobalMsg): Watcher =
+      fromDate(interval, id, dt => toMsg(Millis(dt.getTime().toLong)))
 
     /** Creates a watcher that repeatedly emits messages at regular intervals. */
     def every(interval: Seconds, id: String, toMsg: Seconds => GlobalMsg): Watcher =
-      Watcher.fromSub {
-        val f: js.Date => GlobalMsg =
-          dt =>
-            val s: Double = dt.getTime() / 1000
-            toMsg(Seconds(s))
-
-        SubJsOps
-          .every[IO](FiniteDuration(interval.toMillis.toLong, TimeUnit.MILLISECONDS), id)
-          .map(f)
-      }
+      fromDate(interval, id, dt => toMsg(Seconds(dt.getTime() / 1000)))
 
     /** Creates a watcher that repeatedly emits messages at regular intervals. */
     def every(interval: Millis, toMsg: Millis => GlobalMsg): Watcher =

--- a/tyrian/test/src-js/tyrian/WatcherTests.scala
+++ b/tyrian/test/src-js/tyrian/WatcherTests.scala
@@ -1,0 +1,63 @@
+package tyrian
+
+import cats.effect.IO
+import indigoengine.shared.datatypes.*
+import scala.scalajs.js
+
+import tyrian.syntax.*
+
+@SuppressWarnings(Array("scalafix:DisableSyntax.throw", "scalafix:DisableSyntax.var"))
+class WatcherJsTests extends munit.CatsEffectSuite {
+
+  type Obs[A] = IO[(Either[Throwable, A] => Unit) => IO[Option[IO[Unit]]]]
+
+  final case class IntMsg(i: Int) extends GlobalMsg
+
+  import ActionWatcherUtils.*
+
+  test("map - Empty") {
+    assertEquals(Watcher.None.map(_ => IntMsg(10)), Watcher.None)
+  }
+
+  test("Run") {
+    var state = 0
+
+    val callback: Either[Throwable, Int] => Unit = {
+      case Right(i) => state = i; ()
+      case Left(_)  => throw new Exception("failed")
+    }
+
+    val observable: Obs[Int] = IO.delay { cb =>
+      cb(Right(10))
+      IO(Option(IO(())))
+    }
+
+    val runnable =
+      Watcher.Observe("test", observable, i => Option(IntMsg(i)))
+
+    runnable.run(callback).map(_ => state == 10).assert
+  }
+
+  test("fromDate - preserves the js.Date value") {
+    val watcher = Watcher.fromDate(100.millis, "test", date => IntMsg(date.getTime().toInt))
+
+    watcher match
+      case Watcher.Observe(_, _, toMsg: (js.Date => Option[GlobalMsg]) @unchecked) =>
+        assertEquals(toMsg(new js.Date(123.0)), Option(IntMsg(123)))
+
+      case _ =>
+        fail("unexpected watcher type")
+  }
+
+  test("every - still maps the current date to Millis") {
+    val watcher = Watcher.every(100.millis, "test", millis => IntMsg(millis.toLong.toInt))
+
+    watcher match
+      case Watcher.Observe(_, _, toMsg: (js.Date => Option[GlobalMsg]) @unchecked) =>
+        assertEquals(toMsg(new js.Date(123.0)), Option(IntMsg(123)))
+
+      case _ =>
+        fail("unexpected watcher type")
+  }
+
+}


### PR DESCRIPTION
## Summary

Adds a JS-only `Watcher.fromDate` helper that exposes the underlying `js.Date` from interval watchers.

## Motivation

`Sub.every` allows consumers to receive the current `js.Date` on each interval tick. In contrast, `Watcher.every` only exposes `Millis` or `Seconds`, which makes it impossible to access the current date and time through the watcher API.

This change restores that capability while preserving the existing `Watcher.every` behavior.

## Changes

* Added `Watcher.fromDate` for JS targets
* Kept existing `Watcher.every` overloads unchanged
* Added JS regression tests covering:

  * date-preserving watcher behavior
  * existing duration-based watcher behavior

## Testing

Validated with:

```bash
./mill.bat --no-server tyrian.js.test
```

Result:

* All tests passed
* Existing watcher tests passed
* New watcher regression tests passed

## Notes

This is a minimal, backward-compatible change that introduces the requested functionality without altering existing APIs or behavior.
