### PR TITLE
Various Tyrian fixes to do with exiting the running app

### DIFF
--- a/tyrian-platform/src/tyrian/platform/runtime/TyrianRuntime.scala
+++ b/tyrian-platform/src/tyrian/platform/runtime/TyrianRuntime.scala
@@ -68,9 +68,7 @@ object TyrianRuntime:
         } yield ()
       }.foreverM
 
-    msgLoop.background.surround {
-      runCmd(initCmd) *> model.get.flatMap(m => runSub(subscriptions(m))) *> F.never
-    }
+    runCmd(initCmd) *> model.get.flatMap(m => runSub(subscriptions(m))) *> msgLoop
 
   @SuppressWarnings(Array("scalafix:DisableSyntax.throw"))
   def runCommands[F[_], Msg](msgQueue: Queue[F, Msg])(cmd: Cmd[F, Msg])(using F: Async[F]): F[Unit] =

--- a/tyrian-sandboxes/sandbox-terminal/src/sandbox/SandboxTerminal.scala
+++ b/tyrian-sandboxes/sandbox-terminal/src/sandbox/SandboxTerminal.scala
@@ -5,7 +5,7 @@ import tyrian.syntax.*
 
 object SandboxTerminal extends App[Unit, Model]:
 
-  def init(args: Array[String]): Result[Model] =
+  def init(args: List[String]): Result[Model] =
     Result(Model(None))
       .addActions(Action.fireAndForget(println("Starting my command line app!")))
 
@@ -33,8 +33,11 @@ object SandboxTerminal extends App[Unit, Model]:
       Watcher.every(1.second, t => Msg.Tick(t))
     )
 
-  def extensions(args: Array[String], model: Model): Set[Extension[Unit, TerminalFragment]] =
+  def extensions(args: List[String], model: Model): Set[Extension[Unit, TerminalFragment]] =
     Set()
+
+  def teardown: Unit =
+    println("Goodbye!")
 
 final case class Model(elapsed: Option[Seconds])
 

--- a/tyrian-sandboxes/sandbox-terminal/src/sandbox/SandboxTerminal.scala
+++ b/tyrian-sandboxes/sandbox-terminal/src/sandbox/SandboxTerminal.scala
@@ -13,6 +13,10 @@ object SandboxTerminal extends App[Unit, Model]:
     case Msg.Tick(t) =>
       Result(model.copy(elapsed = Some(t)))
 
+    case Msg.Quit =>
+      // Result(model).exit
+      Result(throw Exception("Boom"))
+
     case Msg.NoOp =>
       Result(model)
 
@@ -30,7 +34,8 @@ object SandboxTerminal extends App[Unit, Model]:
 
   def watchers(model: Model): Batch[Watcher] =
     Batch(
-      Watcher.every(1.second, t => Msg.Tick(t))
+      Watcher.every(1.second, t => Msg.Tick(t)),
+      Watcher.timeout(5.seconds, Msg.Quit, "quit")
     )
 
   def extensions(args: List[String], model: Model): Set[Extension[Unit, TerminalFragment]] =
@@ -44,3 +49,4 @@ final case class Model(elapsed: Option[Seconds])
 enum Msg extends GlobalMsg:
   case NoOp
   case Tick(t: Seconds)
+  case Quit

--- a/tyrian-sandboxes/sandbox-terminal/src/sandbox/SandboxTerminal.scala
+++ b/tyrian-sandboxes/sandbox-terminal/src/sandbox/SandboxTerminal.scala
@@ -14,8 +14,7 @@ object SandboxTerminal extends App[Unit, Model]:
       Result(model.copy(elapsed = Some(t)))
 
     case Msg.Quit =>
-      // Result(model).exit
-      Result(throw Exception("Boom"))
+      Result(model).exit
 
     case Msg.NoOp =>
       Result(model)

--- a/tyrian-shared/src/tyrian/Action.scala
+++ b/tyrian-shared/src/tyrian/Action.scala
@@ -1,5 +1,6 @@
 package tyrian
 
+import cats.effect.ExitCode
 import cats.effect.IO
 import indigoengine.shared.collections.Batch
 import indigoengine.shared.datatypes.Millis
@@ -49,6 +50,24 @@ object Action:
   /** Creates an action that runs a side effect without producing a message. */
   def sideEffect(thunk: => Unit): Action =
     Action.SideEffect(thunk)
+
+  /** Requests that the (terminal) app shut itself down cleanly with `ExitCode.Success`. Has no effect on the JS
+    * frontend.
+    */
+  def exit: Action =
+    Exit(ExitCode.Success)
+
+  /** Requests that the (terminal) app shut itself down cleanly with the given exit code. Has no effect on the JS
+    * frontend.
+    */
+  def exit(code: ExitCode): Action =
+    Exit(code)
+
+  /** Requests that the (terminal) app shut itself down cleanly with the given exit code. Has no effect on the JS
+    * frontend.
+    */
+  def exit(code: Int): Action =
+    Exit(ExitCode(code))
 
   /** Alias for sideEffect. */
   def fireAndForget(thunk: => Unit): Action =
@@ -133,6 +152,15 @@ object Action:
 
     def apply(run: => GlobalMsg): Run[GlobalMsg] =
       Run(IO(run), identity)
+
+  /** Requests that the app shut itself down. Intercepted by the terminal runtime and ignored everywhere else.
+    */
+  private[tyrian] final case class Exit(code: ExitCode) extends Action:
+    def map(f: GlobalMsg => GlobalMsg): Exit =
+      this
+
+    def toCmd: Cmd[IO, Nothing] =
+      Cmd.None
 
   object internal:
 

--- a/tyrian-shared/src/tyrian/Result.scala
+++ b/tyrian-shared/src/tyrian/Result.scala
@@ -1,5 +1,6 @@
 package tyrian
 
+import cats.effect.ExitCode
 import cats.effect.IO
 import indigoengine.shared.collections.Batch
 import tyrian.classic.cmds.Logger
@@ -48,6 +49,13 @@ sealed trait Result[+A] derives CanEqual:
   def addGlobalMsgs(msgs: GlobalMsg*): Result[A] =
     addGlobalMsgs(Batch.fromSeq(msgs))
 
+  def exit: Result[A] =
+    addActions(Action.exit)
+  def exit(code: ExitCode): Result[A] =
+    addActions(Action.exit(code))
+  def exit(code: Int): Result[A] =
+    exit(ExitCode(code))
+
   def createActions(f: A => Batch[Action]): Result[A]
 
   def clearActions: Result[A]
@@ -71,6 +79,10 @@ sealed trait Result[+A] derives CanEqual:
   def flatMap[B](f: A => Result[B]): Result[B]
 
 object Result:
+
+  private val defaultCrashLogging: PartialFunction[Throwable, String] = { case (e: Throwable) =>
+    e.getMessage + "\n" + e.getStackTrace().mkString("\n")
+  }
 
   final case class Next[+A](state: A, actions: Batch[Action]) extends Result[A] {
 
@@ -184,9 +196,7 @@ object Result:
       this.copy(crashReporter = reporter)
 
     def reportCrash: String =
-      crashReporter.orElse[Throwable, String] { case (e: Throwable) =>
-        e.getMessage + "\n" + e.getStackTrace.mkString("\n")
-      }(e)
+      crashReporter.orElse(defaultCrashLogging)(e)
 
     def addActions(newActions: Action*): Error                               = this
     def addActions(newActions: Batch[Action]): Error                         = this
@@ -206,7 +216,7 @@ object Result:
 
   object Error {
     def apply(e: Throwable): Error =
-      Error(e, { case (ee: Throwable) => ee.getMessage })
+      Error(e, defaultCrashLogging)
   }
 
   extension [A](l: Batch[Result[A]]) def sequence: Result[Batch[A]] = Result.sequenceBatch(l)

--- a/tyrian-terminal/src-jvm/tyrian/App.scala
+++ b/tyrian-terminal/src-jvm/tyrian/App.scala
@@ -2,23 +2,22 @@ package tyrian
 
 import cats.effect.ExitCode
 import cats.effect.IO
-import cats.effect.kernel.Outcome
+import tyrian.internal.ExitSignal
 
 trait App[GraphicsContext, Model] extends internal.AppBase[GraphicsContext, Model]:
 
   def run(args: List[String]): IO[ExitCode] =
-    appStart(args)
-      .guaranteeCase {
-        case Outcome.Canceled() =>
-          // cancelled, e.g. Ctrl+C
-          IO(teardown)
+    appStart(args).attempt
+      .flatMap {
+        case Left(ExitSignal(code)) =>
+          // The app shut itself down cleanly via Result.exit / Action.exit
+          IO(teardown).as(code)
 
-        case Outcome.Errored(e) =>
-          IO(teardown) *>
-            IO.println(s"App exited following an error:\n${e.getMessage}")
+        case Left(e) =>
+          IO(teardown).as(ExitCode.Error)
 
-        case Outcome.Succeeded(_) =>
-          // Exited because the app presumably shut itself down cleanly, nothing to do.
-          IO(teardown)
+        case Right(n) =>
+          // Unreachable: Here for completeness
+          n
       }
-      .as(ExitCode.Success)
+      .onCancel(IO(teardown)) // cancelled, e.g. Ctrl+C / SIGTERM

--- a/tyrian-terminal/src-jvm/tyrian/App.scala
+++ b/tyrian-terminal/src-jvm/tyrian/App.scala
@@ -1,0 +1,24 @@
+package tyrian
+
+import cats.effect.ExitCode
+import cats.effect.IO
+import cats.effect.kernel.Outcome
+
+trait App[GraphicsContext, Model] extends internal.AppBase[GraphicsContext, Model]:
+
+  def run(args: List[String]): IO[ExitCode] =
+    appStart(args)
+      .guaranteeCase {
+        case Outcome.Canceled() =>
+          // cancelled, e.g. Ctrl+C
+          IO(teardown)
+
+        case Outcome.Errored(e) =>
+          IO(teardown) *>
+            IO.println(s"App exited following an error:\n${e.getMessage}")
+
+        case Outcome.Succeeded(_) =>
+          // Exited because the app presumably shut itself down cleanly, nothing to do.
+          IO(teardown)
+      }
+      .as(ExitCode.Success)

--- a/tyrian-terminal/src-native/tyrian/App.scala
+++ b/tyrian-terminal/src-native/tyrian/App.scala
@@ -1,0 +1,73 @@
+package tyrian
+
+import cats.effect.ExitCode
+import cats.effect.IO
+import cats.effect.kernel.Outcome
+import cats.effect.kernel.Resource
+import cats.syntax.all.*
+
+import java.util.concurrent.atomic.AtomicBoolean
+import scala.concurrent.duration.*
+import scala.scalanative.libc.signal.SIGINT
+import scala.scalanative.libc.signal.SIGTERM
+import scala.scalanative.libc.signal.signal
+import scala.scalanative.unsafe.CFuncPtr1
+import scala.scalanative.unsafe.CInt
+
+trait App[GraphicsContext, Model] extends internal.AppBase[GraphicsContext, Model]:
+
+  def run(args: List[String]): IO[ExitCode] =
+    App.onSignals
+      .use { awaitSignal =>
+        appStart(args).start
+          .flatMap { fiber =>
+            (awaitSignal *> fiber.cancel).background.surround {
+              fiber.join.flatMap {
+                case Outcome.Canceled() =>
+                  // cancelled, e.g. Ctrl+C
+                  IO(teardown)
+
+                case Outcome.Errored(e) =>
+                  IO(teardown) *>
+                    IO.println(s"App exited following an error:\n${e.getMessage}")
+
+                case Outcome.Succeeded(_) =>
+                  // Exited because the app presumably shut itself down cleanly, nothing to do.
+                  IO(teardown)
+              }
+            }
+          }
+      }
+      .as(ExitCode.Success)
+
+object App:
+
+  private val interrupted: AtomicBoolean =
+    new AtomicBoolean(false)
+
+  private val handler: CFuncPtr1[CInt, Unit] =
+    (_: CInt) => interrupted.set(true)
+
+  private def onSignals: Resource[IO, IO[Unit]] =
+    Resource
+      .make(
+        IO {
+          val prevInt  = signal(SIGINT, handler)
+          val prevTerm = signal(SIGTERM, handler)
+
+          (prevInt, prevTerm)
+        }
+      ) { case (prevInt, prevTerm) =>
+        IO(signal(SIGINT, prevInt)).void *>
+          IO(signal(SIGTERM, prevTerm)).void
+      }
+      .as {
+        def loop: IO[Unit] =
+          IO(interrupted.get())
+            .ifM(
+              IO.unit,
+              IO.sleep(50.millis) *> loop
+            )
+
+        loop
+      }

--- a/tyrian-terminal/src-native/tyrian/App.scala
+++ b/tyrian-terminal/src-native/tyrian/App.scala
@@ -5,6 +5,7 @@ import cats.effect.IO
 import cats.effect.kernel.Outcome
 import cats.effect.kernel.Resource
 import cats.syntax.all.*
+import tyrian.internal.ExitSignal
 
 import java.util.concurrent.atomic.AtomicBoolean
 import scala.concurrent.duration.*
@@ -24,21 +25,23 @@ trait App[GraphicsContext, Model] extends internal.AppBase[GraphicsContext, Mode
             (awaitSignal *> fiber.cancel).background.surround {
               fiber.join.flatMap {
                 case Outcome.Canceled() =>
-                  // cancelled, e.g. Ctrl+C
-                  IO(teardown)
+                  // cancelled, e.g. Ctrl+C / SIGTERM
+                  IO(teardown).as(ExitCode.Success)
+
+                case Outcome.Errored(ExitSignal(code)) =>
+                  // The app shut itself down cleanly via Result.exit / Action.exit
+                  IO(teardown).as(code)
 
                 case Outcome.Errored(e) =>
-                  IO(teardown) *>
-                    IO.println(s"App exited following an error:\n${e.getMessage}")
+                  IO(teardown).as(ExitCode.Error)
 
-                case Outcome.Succeeded(_) =>
-                  // Exited because the app presumably shut itself down cleanly, nothing to do.
-                  IO(teardown)
+                case Outcome.Succeeded(fa) =>
+                  // Unreachable: Here for completeness
+                  fa
               }
             }
           }
       }
-      .as(ExitCode.Success)
 
 object App:
 

--- a/tyrian-terminal/src/tyrian/internal/AppBase.scala
+++ b/tyrian-terminal/src/tyrian/internal/AppBase.scala
@@ -1,8 +1,13 @@
-package tyrian
+package tyrian.internal
 
 import cats.effect.IO
-import cats.effect.unsafe.implicits.global
+import cats.effect.IOApp
 import indigoengine.shared.collections.Batch
+import tyrian.Action
+import tyrian.GlobalMsg
+import tyrian.Result
+import tyrian.TerminalFragment
+import tyrian.Watcher
 import tyrian.classic.Terminal
 import tyrian.classic.TyrianApp
 import tyrian.extensions.Extension
@@ -10,14 +15,12 @@ import tyrian.extensions.ExtensionRegister
 import tyrian.platform.Cmd
 import tyrian.platform.Sub
 
-// TODO: Look at making the JS and Native App's common. There are differences, but there's a lot of similarity too.
-
-trait App[GraphicsContext, Model]:
+trait AppBase[GraphicsContext, Model] extends IOApp:
 
   /** Used to initialise your app. Accepts simple flags and produces the initial model state, along with any actions to
     * run at start up, in order to trigger other processes.
     */
-  def init(args: Array[String]): Result[Model]
+  def init(args: List[String]): Result[Model]
 
   /** The update method allows you to modify the model based on incoming messages (events). As well as an updated model,
     * you can also produce actions to run.
@@ -39,12 +42,18 @@ trait App[GraphicsContext, Model]:
     * @param model
     *   The initial app model. Only provided once.
     */
-  def extensions(args: Array[String], model: Model): Set[Extension[GraphicsContext, TerminalFragment]]
+  def extensions(args: List[String], model: Model): Set[Extension[GraphicsContext, TerminalFragment]]
 
-  val run: IO[Nothing] => Unit = _.unsafeRunSync()
+  /** Invoked when terminal apps exit. Provides an opportunity for sign-off messages to the user, or for clean up
+    * side-effects to take place.
+    *
+    * Note: `teardown` may not be invoked if you run the native version through your build tool, but will be invoked if
+    * you run the executable directly.
+    */
+  def teardown: Unit
 
   @SuppressWarnings(Array("scalafix:DisableSyntax.throw"))
-  private def _init(args: Array[String]): (Model, Cmd[IO, GlobalMsg]) =
+  private def _init(args: List[String]): (Model, Cmd[IO, GlobalMsg]) =
     init(args) match
       case Result.Next(state, actions) =>
         (state, Action.internal.Many(actions).toCmd)
@@ -72,8 +81,7 @@ trait App[GraphicsContext, Model]:
   private val extensionsRegister: ExtensionRegister[GraphicsContext, TerminalFragment] =
     new ExtensionRegister()
 
-  def main(args: Array[String]): Unit =
-
+  def appStart(args: List[String]): IO[Nothing] =
     val (initModel, initCmds) =
       _init(args)
 
@@ -108,11 +116,9 @@ trait App[GraphicsContext, Model]:
     def combinedSubscriptions(model: Model): Sub[IO, GlobalMsg] =
       _subscriptions(model) |+| Watcher.internal.Many(extensionsRegister.watchers).toSub
 
-    run(
-      TyrianApp.start[IO, Model, GlobalMsg](
-        initModel -> (initCmds |+| Cmd.Batch(extensionsCmds.toList)),
-        combinedUpdate,
-        combinedView,
-        combinedSubscriptions
-      )
+    TyrianApp.start[IO, Model, GlobalMsg](
+      initModel -> (initCmds |+| Cmd.Batch(extensionsCmds.toList)),
+      combinedUpdate,
+      combinedView,
+      combinedSubscriptions
     )

--- a/tyrian-terminal/src/tyrian/internal/AppBase.scala
+++ b/tyrian-terminal/src/tyrian/internal/AppBase.scala
@@ -1,5 +1,6 @@
 package tyrian.internal
 
+import cats.effect.ExitCode
 import cats.effect.IO
 import cats.effect.IOApp
 import indigoengine.shared.collections.Batch
@@ -69,11 +70,22 @@ trait AppBase[GraphicsContext, Model] extends IOApp:
     case msg =>
       update(model)(msg) match
         case Result.Next(state, actions) =>
-          state -> Action.internal.Many(actions).toCmd
+          findExit(actions) match
+            case Some(code) =>
+              throw ExitSignal(code)
+
+            case None =>
+              state -> Action.internal.Many(actions).toCmd
 
         case e @ Result.Error(err, _) =>
           println(e.reportCrash)
           throw err
+
+  private def findExit(actions: Batch[Action]): Option[ExitCode] =
+    actions.collectFirst {
+      case Action.Exit(code)          => Some(code)
+      case Action.internal.Many(more) => findExit(more)
+    }.flatten
 
   private def _subscriptions(model: Model): Sub[IO, GlobalMsg] =
     Watcher.internal.Many(watchers(model)).toSub
@@ -122,3 +134,5 @@ trait AppBase[GraphicsContext, Model] extends IOApp:
       combinedView,
       combinedSubscriptions
     )
+
+private[tyrian] final case class ExitSignal(code: ExitCode) extends RuntimeException


### PR DESCRIPTION
This fixes two issues in one: Providing a teardown hook (Native +  JVM) and also handling SIGINT (+ SIGTERM) in case someone hits Ctrl+C.

Seems to work just fine.

I think what we're missing now (maybe the description of one of the issues wasn't clear enough) is a way to actually start a shutdown from within the app.

This PR also changes the terminal apps to use a proper `IOApp`.