### PR TITLE
FIXED #166: Remove unused Startupdata from Scene definition

### DIFF
--- a/indigo-sandboxes/perf/src/com/example/perf/PerfGame.scala
+++ b/indigo-sandboxes/perf/src/com/example/perf/PerfGame.scala
@@ -47,7 +47,7 @@ final class PerfGame extends Game[Unit, Dude, DudeModel]:
         )
     }
 
-  def scenes(bootData: Unit): NonEmptyBatch[Scene[Dude, DudeModel]] =
+  def scenes(bootData: Unit): NonEmptyBatch[Scene[DudeModel]] =
     NonEmptyBatch(Scene.empty)
 
   def initialScene(bootData: Unit): Option[SceneName] =

--- a/indigo-sandboxes/physics/src/example/IndigoPhysics.scala
+++ b/indigo-sandboxes/physics/src/example/IndigoPhysics.scala
@@ -11,7 +11,7 @@ final class IndigoPhysics extends Game[Unit, Unit, Model]:
   def initialScene(bootData: Unit): Option[SceneName] =
     None
 
-  def scenes(bootData: Unit): NonEmptyBatch[Scene[Unit, Model]] =
+  def scenes(bootData: Unit): NonEmptyBatch[Scene[Model]] =
     NonEmptyBatch(LoadScene, VolumeScene, BoxesAndBallsScene, BoxesScene, BallsScene)
 
   val eventFilters: EventFilters =

--- a/indigo-sandboxes/physics/src/example/LoadScene.scala
+++ b/indigo-sandboxes/physics/src/example/LoadScene.scala
@@ -3,7 +3,7 @@ package example
 import indigo.*
 import indigo.scenes.*
 
-object LoadScene extends Scene[Unit, Model]:
+object LoadScene extends Scene[Model]:
 
   type SceneModel = Unit
 

--- a/indigo-sandboxes/physics/src/example/PhysicsScene.scala
+++ b/indigo-sandboxes/physics/src/example/PhysicsScene.scala
@@ -3,7 +3,7 @@ package example
 import indigo.*
 import indigo.physics.*
 
-trait PhysicsScene extends Scene[Unit, Model]:
+trait PhysicsScene extends Scene[Model]:
 
   def world(dice: Dice): World[MyTag]
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/SandboxGame.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/SandboxGame.scala
@@ -15,7 +15,7 @@ final class SandboxGame extends Game[SandboxBootData, SandboxStartupData, Sandbo
   def initialScene(bootData: SandboxBootData): Option[SceneName] =
     Some(BgAudioScene.name)
 
-  def scenes(bootData: SandboxBootData): NonEmptyBatch[Scene[SandboxStartupData, SandboxGameModel]] =
+  def scenes(bootData: SandboxBootData): NonEmptyBatch[Scene[SandboxGameModel]] =
     ScenesList.scenes
 
   val eventFilters: EventFilters = EventFilters.Permissive

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ActorPoolPhysicsScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ActorPoolPhysicsScene.scala
@@ -3,14 +3,13 @@ package com.example.sandbox.scenes
 import com.example.sandbox.Constants
 import com.example.sandbox.SandboxGame
 import com.example.sandbox.SandboxGameModel
-import com.example.sandbox.SandboxStartupData
 import indigo.*
 import indigo.physics.*
 import indigo.scenes.*
 import indigo.syntax.*
 import indigoextras.actors.*
 
-object ActorPoolPhysicsScene extends Scene[SandboxStartupData, SandboxGameModel]:
+object ActorPoolPhysicsScene extends Scene[SandboxGameModel]:
 
   type SceneModel = ActorPhysicsSceneModel
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ActorPoolScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ActorPoolScene.scala
@@ -3,13 +3,12 @@ package com.example.sandbox.scenes
 import com.example.sandbox.Constants
 import com.example.sandbox.SandboxGame
 import com.example.sandbox.SandboxGameModel
-import com.example.sandbox.SandboxStartupData
 import indigo.*
 import indigo.scenes.*
 import indigo.syntax.*
 import indigoextras.actors.*
 
-object ActorPoolScene extends Scene[SandboxStartupData, SandboxGameModel]:
+object ActorPoolScene extends Scene[SandboxGameModel]:
 
   type SceneModel = ActorSceneModel
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/BgAudioScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/BgAudioScene.scala
@@ -3,14 +3,13 @@ package com.example.sandbox.scenes
 import com.example.sandbox.Fonts
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGameModel
-import com.example.sandbox.SandboxStartupData
 import indigo.*
 import indigo.scenes.*
 
 import scala.annotation.nowarn
 
 @nowarn("msg=unused")
-object BgAudioScene extends Scene[SandboxStartupData, SandboxGameModel]:
+object BgAudioScene extends Scene[SandboxGameModel]:
 
   type SceneModel = Unit
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/BoundingCircleScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/BoundingCircleScene.scala
@@ -2,11 +2,10 @@ package com.example.sandbox.scenes
 
 import com.example.sandbox.SandboxGame
 import com.example.sandbox.SandboxGameModel
-import com.example.sandbox.SandboxStartupData
 import indigo.*
 import indigo.scenes.*
 
-object BoundingCircleScene extends Scene[SandboxStartupData, SandboxGameModel]:
+object BoundingCircleScene extends Scene[SandboxGameModel]:
 
   type SceneModel = SandboxGameModel
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/BoundsScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/BoundsScene.scala
@@ -4,12 +4,11 @@ import com.example.sandbox.Fonts
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGame
 import com.example.sandbox.SandboxGameModel
-import com.example.sandbox.SandboxStartupData
 import indigo.*
 import indigo.scenes.*
 import indigo.syntax.*
 
-object BoundsScene extends Scene[SandboxStartupData, SandboxGameModel]:
+object BoundsScene extends Scene[SandboxGameModel]:
 
   type SceneModel = SandboxGameModel
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/BoxesScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/BoxesScene.scala
@@ -1,11 +1,10 @@
 package com.example.sandbox.scenes
 
 import com.example.sandbox.SandboxGameModel
-import com.example.sandbox.SandboxStartupData
 import indigo.*
 import indigo.scenes.*
 
-object BoxesScene extends Scene[SandboxStartupData, SandboxGameModel]:
+object BoxesScene extends Scene[SandboxGameModel]:
 
   type SceneModel = SandboxGameModel
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/CameraScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/CameraScene.scala
@@ -3,11 +3,10 @@ package com.example.sandbox.scenes
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGame
 import com.example.sandbox.SandboxGameModel
-import com.example.sandbox.SandboxStartupData
 import indigo.*
 import indigo.scenes.*
 
-object CameraScene extends Scene[SandboxStartupData, SandboxGameModel] {
+object CameraScene extends Scene[SandboxGameModel] {
 
   type SceneModel = SandboxGameModel
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/CameraWithCloneTilesScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/CameraWithCloneTilesScene.scala
@@ -2,12 +2,11 @@ package com.example.sandbox.scenes
 
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGameModel
-import com.example.sandbox.SandboxStartupData
 import indigo.*
 import indigo.scenes.*
 import indigo.syntax.*
 
-object CameraWithCloneTilesScene extends Scene[SandboxStartupData, SandboxGameModel]:
+object CameraWithCloneTilesScene extends Scene[SandboxGameModel]:
 
   type SceneModel = Unit
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/CaptureScreenScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/CaptureScreenScene.scala
@@ -8,14 +8,13 @@ import com.example.sandbox.DudeUp
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGame
 import com.example.sandbox.SandboxGameModel
-import com.example.sandbox.SandboxStartupData
 import indigo.*
 import indigo.core.events.ScreenCaptureEvent
 import indigo.scenegraph.Shape
 import indigo.scenegraph.Shape.Box
 import indigo.scenes.*
 
-object CaptureScreenScene extends Scene[SandboxStartupData, SandboxGameModel]:
+object CaptureScreenScene extends Scene[SandboxGameModel]:
 
   type SceneModel = SandboxGameModel
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ClipScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ClipScene.scala
@@ -3,12 +3,11 @@ package com.example.sandbox.scenes
 import com.example.sandbox.Fonts
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGameModel
-import com.example.sandbox.SandboxStartupData
 import indigo.*
 import indigo.scenes.*
 import indigo.syntax.*
 
-object ClipScene extends Scene[SandboxStartupData, SandboxGameModel]:
+object ClipScene extends Scene[SandboxGameModel]:
 
   type SceneModel = SandboxGameModel
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ComponentUIScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ComponentUIScene.scala
@@ -3,13 +3,12 @@ package com.example.sandbox.scenes
 import com.example.sandbox.Constants
 import com.example.sandbox.Log
 import com.example.sandbox.SandboxGameModel
-import com.example.sandbox.SandboxStartupData
 import indigo.*
 import indigo.scenes.*
 import indigoextras.ui.*
 import indigoextras.ui.syntax.*
 
-object ComponentUIScene extends Scene[SandboxStartupData, SandboxGameModel]:
+object ComponentUIScene extends Scene[SandboxGameModel]:
 
   type SceneModel = SandboxGameModel
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ComponentUIScene2.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ComponentUIScene2.scala
@@ -4,14 +4,13 @@ import com.example.sandbox.Fonts
 import com.example.sandbox.Log
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGameModel
-import com.example.sandbox.SandboxStartupData
 import indigo.*
 import indigo.scenes.*
 import indigo.syntax.*
 import indigoextras.ui.*
 import indigoextras.ui.syntax.*
 
-object ComponentUIScene2 extends Scene[SandboxStartupData, SandboxGameModel]:
+object ComponentUIScene2 extends Scene[SandboxGameModel]:
 
   type SceneModel = SandboxGameModel
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ConfettiScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ConfettiScene.scala
@@ -4,11 +4,10 @@ import com.example.sandbox.Fonts
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGame
 import com.example.sandbox.SandboxGameModel
-import com.example.sandbox.SandboxStartupData
 import indigo.*
 import indigo.scenes.*
 
-object ConfettiScene extends Scene[SandboxStartupData, SandboxGameModel]:
+object ConfettiScene extends Scene[SandboxGameModel]:
 
   val spawnCount: Int = 600
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/CratesScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/CratesScene.scala
@@ -2,11 +2,10 @@ package com.example.sandbox.scenes
 
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGameModel
-import com.example.sandbox.SandboxStartupData
 import indigo.*
 import indigo.scenes.*
 
-object CratesScene extends Scene[SandboxStartupData, SandboxGameModel]:
+object CratesScene extends Scene[SandboxGameModel]:
 
   type SceneModel = Unit
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/LegacyEffectsScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/LegacyEffectsScene.scala
@@ -3,7 +3,6 @@ package com.example.sandbox.scenes
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGame
 import com.example.sandbox.SandboxGameModel
-import com.example.sandbox.SandboxStartupData
 import indigo.*
 import indigo.scenes.*
 import indigoextras.effectmaterials.Border
@@ -11,7 +10,7 @@ import indigoextras.effectmaterials.Glow
 import indigoextras.effectmaterials.LegacyEffects
 import indigoextras.effectmaterials.Thickness
 
-object LegacyEffectsScene extends Scene[SandboxStartupData, SandboxGameModel] {
+object LegacyEffectsScene extends Scene[SandboxGameModel] {
 
   type SceneModel = SandboxGameModel
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/LightsScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/LightsScene.scala
@@ -2,11 +2,10 @@ package com.example.sandbox.scenes
 
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGameModel
-import com.example.sandbox.SandboxStartupData
 import indigo.*
 import indigo.scenes.*
 
-object LightsScene extends Scene[SandboxStartupData, SandboxGameModel] {
+object LightsScene extends Scene[SandboxGameModel] {
 
   type SceneModel = SandboxGameModel
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/LineReflectionScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/LineReflectionScene.scala
@@ -4,12 +4,11 @@ import com.example.sandbox.Fonts
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGame
 import com.example.sandbox.SandboxGameModel
-import com.example.sandbox.SandboxStartupData
 import indigo.*
 import indigo.scenes.*
 import indigo.syntax.*
 
-object LineReflectionScene extends Scene[SandboxStartupData, SandboxGameModel]:
+object LineReflectionScene extends Scene[SandboxGameModel]:
 
   type SceneModel = Radians
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ManyEventHandlers.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ManyEventHandlers.scala
@@ -1,11 +1,10 @@
 package com.example.sandbox.scenes
 
 import com.example.sandbox.SandboxGameModel
-import com.example.sandbox.SandboxStartupData
 import indigo.*
 import indigo.scenes.*
 
-object ManyEventHandlers extends Scene[SandboxStartupData, SandboxGameModel]:
+object ManyEventHandlers extends Scene[SandboxGameModel]:
 
   type SceneModel = SandboxGameModel
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/MeshScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/MeshScene.scala
@@ -1,12 +1,11 @@
 package com.example.sandbox.scenes
 
 import com.example.sandbox.SandboxGameModel
-import com.example.sandbox.SandboxStartupData
 import indigo.*
 import indigo.scenes.*
 import indigoextras.mesh.*
 
-object MeshScene extends Scene[SandboxStartupData, SandboxGameModel]:
+object MeshScene extends Scene[SandboxGameModel]:
 
   type SceneModel = SandboxGameModel
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/MultiPointScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/MultiPointScene.scala
@@ -3,7 +3,6 @@ package com.example.sandbox.scenes
 import com.example.sandbox.Fonts
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGameModel
-import com.example.sandbox.SandboxStartupData
 import indigo.*
 import indigo.scenes.*
 import org.scalajs.dom
@@ -15,7 +14,7 @@ import scala.math.BigDecimal.RoundingMode
 // Each box contains position, button down, state (down/up), and pressure (if applicable)
 
 @nowarn("msg=unused")
-object MultiPointScene extends Scene[SandboxStartupData, SandboxGameModel]:
+object MultiPointScene extends Scene[SandboxGameModel]:
   // disabling default browser touch actions
   val style = dom.document.createElement("style")
   style.innerHTML = "canvas { touch-action: none }"

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/MutantsScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/MutantsScene.scala
@@ -3,12 +3,11 @@ package com.example.sandbox.scenes
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGame
 import com.example.sandbox.SandboxGameModel
-import com.example.sandbox.SandboxStartupData
 import indigo.*
 import indigo.scenes.*
 import indigo.syntax.*
 
-object MutantsScene extends Scene[SandboxStartupData, SandboxGameModel]:
+object MutantsScene extends Scene[SandboxGameModel]:
 
   type SceneModel = SandboxGameModel
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/NineSliceScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/NineSliceScene.scala
@@ -2,11 +2,10 @@ package com.example.sandbox.scenes
 
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGameModel
-import com.example.sandbox.SandboxStartupData
 import indigo.*
 import indigo.scenes.*
 
-object NineSliceScene extends Scene[SandboxStartupData, SandboxGameModel] {
+object NineSliceScene extends Scene[SandboxGameModel] {
 
   type SceneModel = SandboxGameModel
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/OriginalScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/OriginalScene.scala
@@ -2,12 +2,11 @@ package com.example.sandbox.scenes
 
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGameModel
-import com.example.sandbox.SandboxStartupData
 import com.example.sandbox.SandboxView
 import indigo.*
 import indigo.scenes.*
 
-object OriginalScene extends Scene[SandboxStartupData, SandboxGameModel] {
+object OriginalScene extends Scene[SandboxGameModel] {
 
   type SceneModel = SandboxGameModel
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/PathFindingScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/PathFindingScene.scala
@@ -15,7 +15,7 @@ final case class PathFindingModel(
 object PathFindingModel:
   val empty: PathFindingModel = PathFindingModel(Batch.empty)
 
-object PathFindingScene extends Scene[SandboxStartupData, SandboxGameModel]:
+object PathFindingScene extends Scene[SandboxGameModel]:
 
   type SceneModel = PathFindingModel
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/PerformerPhysicsScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/PerformerPhysicsScene.scala
@@ -3,14 +3,13 @@ package com.example.sandbox.scenes
 import com.example.sandbox.Constants
 import com.example.sandbox.SandboxGame
 import com.example.sandbox.SandboxGameModel
-import com.example.sandbox.SandboxStartupData
 import indigo.*
 import indigo.physics.*
 import indigo.scenes.*
 import indigo.syntax.*
 import indigoextras.performers.*
 
-object PerformerPhysicsScene extends Scene[SandboxStartupData, SandboxGameModel]:
+object PerformerPhysicsScene extends Scene[SandboxGameModel]:
 
   type SceneModel = PerformerPhysicsSceneModel
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/PerformerScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/PerformerScene.scala
@@ -3,13 +3,12 @@ package com.example.sandbox.scenes
 import com.example.sandbox.Constants
 import com.example.sandbox.SandboxGame
 import com.example.sandbox.SandboxGameModel
-import com.example.sandbox.SandboxStartupData
 import indigo.*
 import indigo.scenes.*
 import indigo.syntax.*
 import indigoextras.performers.*
 
-object PerformerScene extends Scene[SandboxStartupData, SandboxGameModel]:
+object PerformerScene extends Scene[SandboxGameModel]:
 
   type SceneModel = PerformerSceneModel
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/PointersScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/PointersScene.scala
@@ -3,7 +3,6 @@ package com.example.sandbox.scenes
 import com.example.sandbox.Fonts
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGameModel
-import com.example.sandbox.SandboxStartupData
 import indigo.*
 import indigo.scenes.*
 import org.scalajs.dom
@@ -11,7 +10,7 @@ import org.scalajs.dom
 import scala.annotation.nowarn
 
 @nowarn("msg=unused")
-object PointersScene extends Scene[SandboxStartupData, SandboxGameModel]:
+object PointersScene extends Scene[SandboxGameModel]:
   // disabling default browser touch actions
   val style = dom.document.createElement("style")
   style.innerHTML = "canvas { touch-action: none }"

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/RefractionScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/RefractionScene.scala
@@ -3,13 +3,12 @@ package com.example.sandbox.scenes
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGame
 import com.example.sandbox.SandboxGameModel
-import com.example.sandbox.SandboxStartupData
 import indigo.*
 import indigo.scenes.*
 import indigoextras.effectmaterials.Refraction
 import indigoextras.effectmaterials.RefractionEntity
 
-object RefractionScene extends Scene[SandboxStartupData, SandboxGameModel] {
+object RefractionScene extends Scene[SandboxGameModel] {
 
   type SceneModel = SandboxGameModel
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ScenesList.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ScenesList.scala
@@ -1,12 +1,11 @@
 package com.example.sandbox.scenes
 
 import com.example.sandbox.SandboxGameModel
-import com.example.sandbox.SandboxStartupData
 import indigo.*
 
 object ScenesList:
 
-  val scenes: NonEmptyBatch[Scene[SandboxStartupData, SandboxGameModel]] =
+  val scenes: NonEmptyBatch[Scene[SandboxGameModel]] =
     NonEmptyBatch(
       OriginalScene,
       ShapesScene,

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/SfxScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/SfxScene.scala
@@ -4,14 +4,13 @@ import com.example.sandbox.Constants
 import com.example.sandbox.Log
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGameModel
-import com.example.sandbox.SandboxStartupData
 import example.TestFont
 import indigo.*
 import indigo.scenes.*
 import indigoextras.ui.*
 import indigoextras.ui.syntax.*
 
-object SfxScene extends Scene[SandboxStartupData, SandboxGameModel]:
+object SfxScene extends Scene[SandboxGameModel]:
 
   type SceneModel = SandboxGameModel
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ShapesScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ShapesScene.scala
@@ -1,11 +1,10 @@
 package com.example.sandbox.scenes
 
 import com.example.sandbox.SandboxGameModel
-import com.example.sandbox.SandboxStartupData
 import indigo.*
 import indigo.scenes.*
 
-object ShapesScene extends Scene[SandboxStartupData, SandboxGameModel]:
+object ShapesScene extends Scene[SandboxGameModel]:
 
   type SceneModel = SandboxGameModel
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/TextScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/TextScene.scala
@@ -3,12 +3,11 @@ package com.example.sandbox.scenes
 import com.example.sandbox.Fonts
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGameModel
-import com.example.sandbox.SandboxStartupData
 import example.TestFont
 import indigo.*
 import indigo.scenes.*
 
-object TextScene extends Scene[SandboxStartupData, SandboxGameModel] {
+object TextScene extends Scene[SandboxGameModel] {
 
   type SceneModel = SandboxGameModel
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/TextureTileScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/TextureTileScene.scala
@@ -3,11 +3,10 @@ package com.example.sandbox.scenes
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGame
 import com.example.sandbox.SandboxGameModel
-import com.example.sandbox.SandboxStartupData
 import indigo.*
 import indigo.scenes.*
 
-object TextureTileScene extends Scene[SandboxStartupData, SandboxGameModel] {
+object TextureTileScene extends Scene[SandboxGameModel] {
 
   type SceneModel = SandboxGameModel
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/TimelineScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/TimelineScene.scala
@@ -3,13 +3,12 @@ package com.example.sandbox.scenes
 import com.example.sandbox.Dude
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGameModel
-import com.example.sandbox.SandboxStartupData
 import indigo.*
 import indigo.scenes.*
 import indigo.syntax.*
 import indigo.syntax.animations.*
 
-object TimelineScene extends Scene[SandboxStartupData, SandboxGameModel]:
+object TimelineScene extends Scene[SandboxGameModel]:
 
   type SceneModel = Dude
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/UltravioletScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/UltravioletScene.scala
@@ -1,14 +1,13 @@
 package com.example.sandbox.scenes
 
 import com.example.sandbox.SandboxGameModel
-import com.example.sandbox.SandboxStartupData
 import indigo.*
 import indigo.scenes.*
 import ultraviolet.syntax.*
 
 import scala.annotation.nowarn
 
-object UltravioletScene extends Scene[SandboxStartupData, SandboxGameModel] {
+object UltravioletScene extends Scene[SandboxGameModel] {
 
   type SceneModel = SandboxGameModel
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ViewportResizeScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ViewportResizeScene.scala
@@ -2,11 +2,10 @@ package com.example.sandbox.scenes
 
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGameModel
-import com.example.sandbox.SandboxStartupData
 import indigo.*
 import indigo.scenes.*
 
-object ViewportResizeScene extends Scene[SandboxStartupData, SandboxGameModel] {
+object ViewportResizeScene extends Scene[SandboxGameModel] {
 
   type SceneModel = SandboxGameModel
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/WaypointScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/WaypointScene.scala
@@ -2,7 +2,6 @@ package com.example.sandbox.scenes
 
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGameModel
-import com.example.sandbox.SandboxStartupData
 import indigo.*
 import indigo.scenes.*
 import indigo.syntax.*
@@ -10,7 +9,7 @@ import indigo.syntax.animations.*
 import indigoextras.waypoints.WaypointPath
 import indigoextras.waypoints.WaypointPathPosition
 
-object WaypointScene extends Scene[SandboxStartupData, SandboxGameModel]:
+object WaypointScene extends Scene[SandboxGameModel]:
 
   type SceneModel = Unit
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/WindowsScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/WindowsScene.scala
@@ -3,13 +3,12 @@ package com.example.sandbox.scenes
 import com.example.sandbox.Constants
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGameModel
-import com.example.sandbox.SandboxStartupData
 import example.TestFont
 import indigo.*
 import indigo.scenes.*
 import indigoextras.ui.*
 
-object WindowsScene extends Scene[SandboxStartupData, SandboxGameModel]:
+object WindowsScene extends Scene[SandboxGameModel]:
 
   type SceneModel = SandboxGameModel
 

--- a/indigo-sandboxes/sandbox/src-native/main/scala/com/example/sandbox/SandboxGame.scala
+++ b/indigo-sandboxes/sandbox/src-native/main/scala/com/example/sandbox/SandboxGame.scala
@@ -10,7 +10,7 @@ final class SandboxGame extends Game[SandboxBootData, SandboxStartupData, Sandbo
   def initialScene(bootData: SandboxBootData): Option[SceneName] =
     Some(ShapesScene.name)
 
-  def scenes(bootData: SandboxBootData): NonEmptyBatch[Scene[SandboxStartupData, SandboxGameModel]] =
+  def scenes(bootData: SandboxBootData): NonEmptyBatch[Scene[SandboxGameModel]] =
     ScenesList.scenes
 
   val eventFilters: EventFilters = EventFilters.Permissive

--- a/indigo-sandboxes/sandbox/src-native/main/scala/com/example/sandbox/scenes/ScenesList.scala
+++ b/indigo-sandboxes/sandbox/src-native/main/scala/com/example/sandbox/scenes/ScenesList.scala
@@ -1,12 +1,11 @@
 package com.example.sandbox.scenes
 
 import com.example.sandbox.SandboxGameModel
-import com.example.sandbox.SandboxStartupData
 import indigo.*
 
 object ScenesList:
 
-  val scenes: NonEmptyBatch[Scene[SandboxStartupData, SandboxGameModel]] =
+  val scenes: NonEmptyBatch[Scene[SandboxGameModel]] =
     NonEmptyBatch(
       ShapesScene
     )

--- a/indigo-sandboxes/sandbox/src-native/main/scala/com/example/sandbox/scenes/ShapesScene.scala
+++ b/indigo-sandboxes/sandbox/src-native/main/scala/com/example/sandbox/scenes/ShapesScene.scala
@@ -1,11 +1,10 @@
 package com.example.sandbox.scenes
 
 import com.example.sandbox.SandboxGameModel
-import com.example.sandbox.SandboxStartupData
 import indigo.*
 import indigo.scenes.*
 
-object ShapesScene extends Scene[SandboxStartupData, SandboxGameModel]:
+object ShapesScene extends Scene[SandboxGameModel]:
 
   type SceneModel = SandboxGameModel
 

--- a/indigo-sandboxes/tyrian-sandbox/src/example/game/GameScene.scala
+++ b/indigo-sandboxes/tyrian-sandbox/src/example/game/GameScene.scala
@@ -3,7 +3,7 @@ package example.game
 import indigo.*
 import indigo.scenes.*
 
-final case class GameScene(clockwise: Boolean) extends Scene[Unit, Unit]:
+final case class GameScene(clockwise: Boolean) extends Scene[Unit]:
 
   type SceneModel = Unit
 

--- a/indigo-sandboxes/tyrian-sandbox/src/example/game/MyAwesomeGame.scala
+++ b/indigo-sandboxes/tyrian-sandbox/src/example/game/MyAwesomeGame.scala
@@ -10,7 +10,7 @@ final case class MyAwesomeGame(id: String, clockwise: Boolean) extends Game[Unit
   def initialScene(bootData: Unit): Option[SceneName] =
     None
 
-  def scenes(bootData: Unit): NonEmptyBatch[Scene[Unit, Unit]] =
+  def scenes(bootData: Unit): NonEmptyBatch[Scene[Unit]] =
     NonEmptyBatch(GameScene(clockwise))
 
   val eventFilters: EventFilters =

--- a/indigo/src-js/indigo/Game.scala
+++ b/indigo/src-js/indigo/Game.scala
@@ -62,7 +62,7 @@ trait Game[BootData, StartUpData, Model]:
     * @return
     *   A list of scenes that ensures at least one scene exists.
     */
-  def scenes(bootData: BootData): NonEmptyBatch[Scene[StartUpData, Model]]
+  def scenes(bootData: BootData): NonEmptyBatch[Scene[Model]]
 
   /** Optional name of the first scene. If None is provided then the first scene is the head of the scenes list.
     *
@@ -187,7 +187,7 @@ trait Game[BootData, StartUpData, Model]:
 
     val subSystemEvents = subSystemsRegister.register(Batch.fromSet(bootUp.subSystems))
 
-    val sceneManager: SceneManager[StartUpData, Model] = {
+    val sceneManager: SceneManager[Model] = {
       val s = scenes(bootUp.bootData)
 
       initialScene(bootUp.bootData) match {
@@ -322,8 +322,8 @@ object Game:
 
     def scenes(
         bootData: ShaderPlayground.Channels
-    ): NonEmptyBatch[Scene[ShaderPlayground.Channels, ShaderPlayground.Model]] =
-      NonEmptyBatch(Scene.empty[ShaderPlayground.Channels, ShaderPlayground.Model])
+    ): NonEmptyBatch[Scene[ShaderPlayground.Model]] =
+      NonEmptyBatch(Scene.empty[ShaderPlayground.Model])
 
     def initialScene(bootData: ShaderPlayground.Channels): Option[SceneName] =
       None

--- a/indigo/src-native/indigo/Game.scala
+++ b/indigo/src-native/indigo/Game.scala
@@ -53,7 +53,7 @@ trait Game[BootData, StartUpData, Model]:
     * @return
     *   A list of scenes that ensures at least one scene exists.
     */
-  def scenes(bootData: BootData): NonEmptyBatch[Scene[StartUpData, Model]]
+  def scenes(bootData: BootData): NonEmptyBatch[Scene[Model]]
 
   /** Optional name of the first scene. If None is provided then the first scene is the head of the scenes list.
     *
@@ -180,7 +180,7 @@ trait Game[BootData, StartUpData, Model]:
 
     val subSystemEvents = subSystemsRegister.register(Batch.fromSet(bootUp.subSystems))
 
-    val sceneManager: SceneManager[StartUpData, Model] = {
+    val sceneManager: SceneManager[Model] = {
       val s = scenes(bootUp.bootData)
 
       initialScene(bootUp.bootData) match {
@@ -317,8 +317,8 @@ object Game:
 
     def scenes(
         bootData: ShaderPlayground.Channels
-    ): NonEmptyBatch[Scene[ShaderPlayground.Channels, ShaderPlayground.Model]] =
-      NonEmptyBatch(Scene.empty[ShaderPlayground.Channels, ShaderPlayground.Model])
+    ): NonEmptyBatch[Scene[ShaderPlayground.Model]] =
+      NonEmptyBatch(Scene.empty[ShaderPlayground.Model])
 
     def initialScene(bootData: ShaderPlayground.Channels): Option[SceneName] =
       None

--- a/indigo/src/indigo/frameprocessors/GameFrameProcessor.scala
+++ b/indigo/src/indigo/frameprocessors/GameFrameProcessor.scala
@@ -13,7 +13,7 @@ import indigoengine.shared.collections.Batch
 
 final class GameFrameProcessor[StartUpData, Model](
     val subSystemsRegister: SubSystemsRegister[Model],
-    val sceneManager: SceneManager[StartUpData, Model],
+    val sceneManager: SceneManager[Model],
     val eventFilters: EventFilters,
     val modelUpdate: (Context, Model) => GlobalEvent => Outcome[Model],
     val _viewUpdate: (Context, Model) => Outcome[SceneUpdateFragment]

--- a/indigo/src/indigo/package.scala
+++ b/indigo/src/indigo/package.scala
@@ -570,7 +570,7 @@ object aliases:
 
   // Scenes
 
-  type Scene[StartUpData, GameModel] = indigo.scenes.Scene[StartUpData, GameModel]
+  type Scene[GameModel] = indigo.scenes.Scene[GameModel]
   val Scene: indigo.scenes.Scene.type = indigo.scenes.Scene
 
   type SceneName = indigo.scenes.SceneName
@@ -585,7 +585,7 @@ object aliases:
   type SceneFinder = indigo.scenes.SceneFinder
   val SceneFinder: indigo.scenes.SceneFinder.type = indigo.scenes.SceneFinder
 
-  type SceneManager[StartUpData, GameModel] = indigo.scenes.SceneManager[StartUpData, GameModel]
+  type SceneManager[GameModel] = indigo.scenes.SceneManager[GameModel]
   val SceneManager: indigo.scenes.SceneManager.type = indigo.scenes.SceneManager
 
 end aliases

--- a/indigo/src/indigo/scenes/Scene.scala
+++ b/indigo/src/indigo/scenes/Scene.scala
@@ -11,7 +11,7 @@ import indigoengine.shared.optics.Lens
 
 /** Describes the functions that a valid scene must implement.
   */
-trait Scene[StartUpData, GameModel] derives CanEqual:
+trait Scene[GameModel] derives CanEqual:
   type SceneModel
 
   def name: SceneName
@@ -28,25 +28,25 @@ trait Scene[StartUpData, GameModel] derives CanEqual:
 
 object Scene {
 
-  def updateModel[SD, GM](
-      scene: Scene[SD, GM],
+  def updateModel[GameModel](
+      scene: Scene[GameModel],
       context: SceneContext,
-      gameModel: GM
-  ): GlobalEvent => Outcome[GM] =
+      gameModel: GameModel
+  ): GlobalEvent => Outcome[GameModel] =
     e =>
       scene
         .updateModel(context, scene.modelLens.get(gameModel))(e)
         .map(scene.modelLens.set(gameModel, _))
 
-  def updateView[SD, GM](
-      scene: Scene[SD, GM],
+  def updateView[GameModel](
+      scene: Scene[GameModel],
       context: SceneContext,
-      model: GM
+      model: GameModel
   ): Outcome[SceneUpdateFragment] =
     scene.present(context, scene.modelLens.get(model))
 
-  def empty[SD, GM]: Scene[SD, GM] =
-    new Scene[SD, GM] {
+  def empty[GameModel]: Scene[GameModel] =
+    new Scene[GameModel] {
       type SceneModel = Unit
 
       val sceneFragment =
@@ -57,13 +57,13 @@ object Scene {
       val name: SceneName =
         SceneName("empty-scene")
 
-      val modelLens: Lens[GM, Unit] =
+      val modelLens: Lens[GameModel, Unit] =
         Lens.unit
 
       val eventFilters: EventFilters =
         EventFilters.BlockAll
 
-      val subSystems: Set[SubSystem[GM]] =
+      val subSystems: Set[SubSystem[GameModel]] =
         Set()
 
       def updateModel(

--- a/indigo/src/indigo/scenes/SceneFinder.scala
+++ b/indigo/src/indigo/scenes/SceneFinder.scala
@@ -101,8 +101,8 @@ final case class SceneFinder(previous: Batch[ScenePosition], current: ScenePosit
 object SceneFinder:
   given CanEqual[Option[SceneFinder], Option[SceneFinder]] = CanEqual.derived
 
-  def fromScenes[StartUpData, GameModel](
-      scenesList: NonEmptyBatch[Scene[StartUpData, GameModel]]
+  def fromScenes[GameModel](
+      scenesList: NonEmptyBatch[Scene[GameModel]]
   ): SceneFinder =
     val a = scenesList.map(_.name).zipWithIndex.map(p => ScenePosition(p._2, p._1))
     SceneFinder(Batch.empty, a.head, a.tail)

--- a/indigo/src/indigo/scenes/SceneManager.scala
+++ b/indigo/src/indigo/scenes/SceneManager.scala
@@ -16,15 +16,10 @@ import indigoengine.shared.datatypes.Seconds
 
 import scala.annotation.nowarn
 
-class SceneManager[StartUpData, GameModel](
-    scenes: NonEmptyBatch[Scene[StartUpData, GameModel]],
+class SceneManager[GameModel](
+    scenes: NonEmptyBatch[Scene[GameModel]],
     scenesFinder: SceneFinder
 ):
-
-  // private given CanEqual[Option[Scene[StartUpData, GameModel]], Option[
-  //   Scene[StartUpData, GameModel]
-  // ]] =
-  //   CanEqual.derived
 
   // Scene management
   @SuppressWarnings(Array("scalafix:DisableSyntax.var"))
@@ -209,11 +204,11 @@ class SceneManager[StartUpData, GameModel](
 
 object SceneManager:
 
-  def apply[StartUpData, GameModel](
-      scenes: NonEmptyBatch[Scene[StartUpData, GameModel]],
+  def apply[GameModel](
+      scenes: NonEmptyBatch[Scene[GameModel]],
       initialScene: SceneName
-  ): SceneManager[StartUpData, GameModel] =
-    new SceneManager[StartUpData, GameModel](
+  ): SceneManager[GameModel] =
+    new SceneManager[GameModel](
       scenes,
-      SceneFinder.fromScenes[StartUpData, GameModel](scenes).jumpToSceneByName(initialScene)
+      SceneFinder.fromScenes(scenes).jumpToSceneByName(initialScene)
     )

--- a/indigo/test/src/indigo/scenes/SceneFinderTests.scala
+++ b/indigo/test/src/indigo/scenes/SceneFinderTests.scala
@@ -7,7 +7,7 @@ class SceneFinderTests extends munit.FunSuite {
 
   import TestScenes._
 
-  val scenes: NonEmptyBatch[Scene[Unit, TestGameModel]] =
+  val scenes: NonEmptyBatch[Scene[TestGameModel]] =
     NonEmptyBatch(sceneA, sceneB)
 
   val sceneFinder: SceneFinder =
@@ -82,7 +82,7 @@ class SceneFinderTests extends munit.FunSuite {
   }
 
   test("scene finder can move to the first and last scenes") {
-    val moreScenes: NonEmptyBatch[Scene[Unit, TestGameModel]] =
+    val moreScenes: NonEmptyBatch[Scene[TestGameModel]] =
       NonEmptyBatch(TestSceneA("a"), TestSceneA("b"), TestSceneA("c"), TestSceneA("d"))
 
     val sf = SceneFinder.fromScenes(moreScenes).jumpToSceneByName(SceneName("c"))

--- a/indigo/test/src/indigo/scenes/SceneManagerTests.scala
+++ b/indigo/test/src/indigo/scenes/SceneManagerTests.scala
@@ -13,7 +13,7 @@ class SceneManagerTests extends munit.FunSuite {
 
   import TestScenes._
 
-  val scenes: NonEmptyBatch[Scene[Unit, TestGameModel]] =
+  val scenes: NonEmptyBatch[Scene[TestGameModel]] =
     NonEmptyBatch(sceneA, sceneB)
 
   val sceneFinder: SceneFinder = SceneFinder.fromScenes(scenes)
@@ -24,12 +24,12 @@ class SceneManagerTests extends munit.FunSuite {
     val events: List[GlobalEvent] =
       List(TestSceneEvent1, TestSceneEvent2, TestSceneEvent3, TestSceneEvent4)
 
-    val sceneManager1 = new SceneManager[Unit, TestGameModel](scenes, sceneFinder)
+    val sceneManager1 = new SceneManager[TestGameModel](scenes, sceneFinder)
     val actual1       = events.map(sceneManager1.eventFilters.modelFilter).collect { case Some(e) => e }
     assertEquals(actual1.length, 1)
     assertEquals(actual1.head, TestSceneEvent1)
 
-    val sceneManager2 = new SceneManager[Unit, TestGameModel](scenes, sceneFinder.forward)
+    val sceneManager2 = new SceneManager[TestGameModel](scenes, sceneFinder.forward)
     val actual2       = events.map(sceneManager2.eventFilters.modelFilter).collect { case Some(e) => e }
     assertEquals(actual2.length, 2)
     assertEquals(actual2, List(TestSceneEvent2, TestSceneEvent3))
@@ -37,7 +37,7 @@ class SceneManagerTests extends munit.FunSuite {
 
   test("A journey through the SceneManager.Should be able to update a model on frametick") {
 
-    val sceneManager = new SceneManager[Unit, TestGameModel](scenes, sceneFinder)
+    val sceneManager = new SceneManager[TestGameModel](scenes, sceneFinder)
 
     val events = Batch(FrameTick)
 
@@ -51,7 +51,7 @@ class SceneManagerTests extends munit.FunSuite {
 
   test("A journey through the SceneManager.Should be able to change scenes and update on frametick") {
 
-    val sceneManager = new SceneManager[Unit, TestGameModel](scenes, sceneFinder)
+    val sceneManager = new SceneManager[TestGameModel](scenes, sceneFinder)
 
     val events = Batch(SceneEvent.Next, FrameTick)
 
@@ -64,7 +64,7 @@ class SceneManagerTests extends munit.FunSuite {
 
   test("A journey through the SceneManager.should be able to move between scenes and update the model accordingly") {
 
-    val sceneManager = new SceneManager[Unit, TestGameModel](scenes, sceneFinder)
+    val sceneManager = new SceneManager[TestGameModel](scenes, sceneFinder)
 
     // A = 2, B = 40
     val events = Batch(
@@ -102,7 +102,7 @@ class SceneManagerTests extends munit.FunSuite {
   private def runModel(
       events: Batch[GlobalEvent],
       model: TestGameModel,
-      sceneManager: SceneManager[Unit, TestGameModel]
+      sceneManager: SceneManager[TestGameModel]
   ): Outcome[TestGameModel] =
     events.foldLeft(Outcome(model))((m, e) => m.flatMap(mm => sceneManager.updateModel(context(6), mm)(e)))
 

--- a/indigo/test/src/indigo/scenes/TestScenes.scala
+++ b/indigo/test/src/indigo/scenes/TestScenes.scala
@@ -16,7 +16,7 @@ object TestScenes {
 
 final case class TestGameModel(sceneA: TestSceneModelA, sceneB: TestSceneModelB)
 
-final case class TestSceneA(id: String) extends Scene[Unit, TestGameModel] {
+final case class TestSceneA(id: String) extends Scene[TestGameModel] {
   type SceneModel = TestSceneModelA
 
   val name: SceneName = SceneName(id)
@@ -56,7 +56,7 @@ final case class TestSceneA(id: String) extends Scene[Unit, TestGameModel] {
 
 final case class TestSceneModelA(count: Int)
 
-final case class TestSceneB(id: String) extends Scene[Unit, TestGameModel] {
+final case class TestSceneB(id: String) extends Scene[TestGameModel] {
   type SceneModel = TestSceneModelB
 
   val name: SceneName = SceneName(id)

--- a/roguelike-starterkit-demo/src/demo/RogueLikeGame.scala
+++ b/roguelike-starterkit-demo/src/demo/RogueLikeGame.scala
@@ -13,7 +13,7 @@ final class RogueLikeGame() extends Game[Unit, Unit, GameModel]:
   def initialScene(bootData: Unit): Option[SceneName] =
     Option(ColourWindowScene.name)
 
-  def scenes(bootData: Unit): NonEmptyBatch[Scene[Unit, GameModel]] =
+  def scenes(bootData: Unit): NonEmptyBatch[Scene[GameModel]] =
     NonEmptyBatch(
       NoTerminalUI,
       ColourWindowScene,

--- a/roguelike-starterkit-demo/src/demo/scenes/ColourWindowScene.scala
+++ b/roguelike-starterkit-demo/src/demo/scenes/ColourWindowScene.scala
@@ -8,7 +8,7 @@ import indigo.*
 import indigoextras.ui.*
 import roguelikestarterkit.*
 
-object ColourWindowScene extends Scene[Unit, GameModel]:
+object ColourWindowScene extends Scene[GameModel]:
 
   type SceneModel = GameModel
 

--- a/roguelike-starterkit-demo/src/demo/scenes/LightingScene.scala
+++ b/roguelike-starterkit-demo/src/demo/scenes/LightingScene.scala
@@ -5,7 +5,7 @@ import demo.models.GameModel
 import indigo.*
 import roguelikestarterkit.*
 
-object LightingScene extends Scene[Unit, GameModel]:
+object LightingScene extends Scene[GameModel]:
 
   type SceneModel = GameModel
 

--- a/roguelike-starterkit-demo/src/demo/scenes/MultipleWindowsScene.scala
+++ b/roguelike-starterkit-demo/src/demo/scenes/MultipleWindowsScene.scala
@@ -8,7 +8,7 @@ import demo.windows.MenuWindow
 import indigo.*
 import indigoextras.ui.*
 
-object MultipleWindowsScene extends Scene[Unit, GameModel]:
+object MultipleWindowsScene extends Scene[GameModel]:
 
   type SceneModel = GameModel
 

--- a/roguelike-starterkit-demo/src/demo/scenes/NoTerminalUI.scala
+++ b/roguelike-starterkit-demo/src/demo/scenes/NoTerminalUI.scala
@@ -12,7 +12,7 @@ import indigoextras.ui.syntax.*
 import roguelikestarterkit.RoguelikeTiles
 import roguelikestarterkit.TerminalMaterial
 
-object NoTerminalUI extends Scene[Unit, GameModel]:
+object NoTerminalUI extends Scene[GameModel]:
 
   type SceneModel = GameModel
 

--- a/roguelike-starterkit-demo/src/demo/scenes/RogueTerminalEmulatorScene.scala
+++ b/roguelike-starterkit-demo/src/demo/scenes/RogueTerminalEmulatorScene.scala
@@ -5,7 +5,7 @@ import demo.models.GameModel
 import indigo.*
 import roguelikestarterkit.*
 
-object RogueTerminalEmulatorScene extends Scene[Unit, GameModel]:
+object RogueTerminalEmulatorScene extends Scene[GameModel]:
 
   type SceneModel = GameModel
 

--- a/roguelike-starterkit-demo/src/demo/scenes/TerminalEmulatorScene.scala
+++ b/roguelike-starterkit-demo/src/demo/scenes/TerminalEmulatorScene.scala
@@ -5,7 +5,7 @@ import demo.models.GameModel
 import indigo.*
 import roguelikestarterkit.*
 
-object TerminalEmulatorScene extends Scene[Unit, GameModel]:
+object TerminalEmulatorScene extends Scene[GameModel]:
 
   type SceneModel = GameModel
 

--- a/roguelike-starterkit-demo/src/demo/scenes/TerminalTextScene.scala
+++ b/roguelike-starterkit-demo/src/demo/scenes/TerminalTextScene.scala
@@ -7,7 +7,7 @@ import roguelikestarterkit.*
 
 import scala.annotation.nowarn
 
-object TerminalTextScene extends Scene[Unit, GameModel]:
+object TerminalTextScene extends Scene[GameModel]:
 
   type SceneModel = GameModel
 

--- a/roguelike-starterkit-demo/src/demo/scenes/TerminalUI.scala
+++ b/roguelike-starterkit-demo/src/demo/scenes/TerminalUI.scala
@@ -9,7 +9,7 @@ import indigoextras.ui.syntax.*
 import roguelikestarterkit.*
 import roguelikestarterkit.ui.*
 
-object TerminalUI extends Scene[Unit, GameModel]:
+object TerminalUI extends Scene[GameModel]:
 
   type SceneModel = GameModel
 

--- a/roguelike-starterkit-demo/src/demo/scenes/WindowDemoScene.scala
+++ b/roguelike-starterkit-demo/src/demo/scenes/WindowDemoScene.scala
@@ -6,7 +6,7 @@ import demo.windows.DemoWindow
 import indigo.*
 import indigoextras.ui.*
 
-object WindowDemoScene extends Scene[Unit, GameModel]:
+object WindowDemoScene extends Scene[GameModel]:
 
   type SceneModel = GameModel
 

--- a/ultraviolet-sandbox/src/com/example/sandbox/SandboxGame.scala
+++ b/ultraviolet-sandbox/src/com/example/sandbox/SandboxGame.scala
@@ -13,7 +13,7 @@ final class SandboxGame extends Game[SandboxBootData, SandboxStartupData, Sandbo
     Some(NoiseScene.name)
 
   def scenes(bootData: SandboxBootData): NonEmptyBatch[
-    Scene[SandboxStartupData, SandboxGameModel]
+    Scene[SandboxGameModel]
   ] =
     NonEmptyBatch(
       OriginalScene,

--- a/ultraviolet-sandbox/src/com/example/sandbox/scenes/NoiseScene.scala
+++ b/ultraviolet-sandbox/src/com/example/sandbox/scenes/NoiseScene.scala
@@ -1,12 +1,11 @@
 package com.example.sandbox.scenes
 
 import com.example.sandbox.SandboxGameModel
-import com.example.sandbox.SandboxStartupData
 import com.example.sandbox.shaders.*
 import indigo.*
 import indigo.scenes.*
 
-object NoiseScene extends Scene[SandboxStartupData, SandboxGameModel] {
+object NoiseScene extends Scene[SandboxGameModel] {
 
   type SceneModel = SandboxGameModel
 

--- a/ultraviolet-sandbox/src/com/example/sandbox/scenes/OriginalScene.scala
+++ b/ultraviolet-sandbox/src/com/example/sandbox/scenes/OriginalScene.scala
@@ -2,14 +2,13 @@ package com.example.sandbox.scenes
 
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGameModel
-import com.example.sandbox.SandboxStartupData
 import com.example.sandbox.SandboxView
 import indigo.*
 import indigo.scenes.*
 import indigo.shaders.*
 import indigo.shaders.ShaderPrimitive.*
 
-object OriginalScene extends Scene[SandboxStartupData, SandboxGameModel] {
+object OriginalScene extends Scene[SandboxGameModel] {
 
   type SceneModel = SandboxGameModel
 

--- a/ultraviolet-sandbox/src/com/example/sandbox/scenes/ShadersScene.scala
+++ b/ultraviolet-sandbox/src/com/example/sandbox/scenes/ShadersScene.scala
@@ -1,12 +1,11 @@
 package com.example.sandbox.scenes
 
 import com.example.sandbox.SandboxGameModel
-import com.example.sandbox.SandboxStartupData
 import com.example.sandbox.shaders.*
 import indigo.*
 import indigo.scenes.*
 
-object ShadersScene extends Scene[SandboxStartupData, SandboxGameModel] {
+object ShadersScene extends Scene[SandboxGameModel] {
 
   type SceneModel = SandboxGameModel
 


### PR DESCRIPTION
The StartupData type parameter on Scene was unused, left over from when Context had the same type param. This PR removes it.