### PR TITLE
FIXED #163: Add a synchronous `prepare` mirror to existing `teardown` process

### DIFF
--- a/indigo/src-js/indigo/Indigo.scala
+++ b/indigo/src-js/indigo/Indigo.scala
@@ -293,6 +293,9 @@ final case class Indigo(
           height = canvas.height
         )
 
+  def prepare(model: Model): Unit =
+    ()
+
   def teardown(model: Model): Unit =
     ()
 

--- a/indigo/src-native/indigo/Indigo.scala
+++ b/indigo/src-native/indigo/Indigo.scala
@@ -189,6 +189,9 @@ final case class Indigo(
   def provideContext(model: Model): Option[SDLContext] =
     None
 
+  def prepare(model: Model): Unit =
+    ()
+
   def teardown(model: Model): Unit =
     ()
 

--- a/tyrian-platform/src/tyrian/platform/runtime/TyrianRuntime.scala
+++ b/tyrian-platform/src/tyrian/platform/runtime/TyrianRuntime.scala
@@ -71,7 +71,7 @@ object TyrianRuntime:
     val initialDraw =
       present.draw(dispatcher, renderer, model, view, onMsg, router)(using F, clock)
 
-    runCmd(initCmd) *> initialDraw *> model.get.flatMap(m => runSub(subscriptions(m))) *> msgLoop
+    initialDraw *> runCmd(initCmd) *> model.get.flatMap(m => runSub(subscriptions(m))) *> msgLoop
 
   @SuppressWarnings(Array("scalafix:DisableSyntax.throw"))
   def runCommands[F[_], Msg](msgQueue: Queue[F, Msg])(cmd: Cmd[F, Msg])(using F: Async[F]): F[Unit] =

--- a/tyrian-platform/src/tyrian/platform/runtime/TyrianRuntime.scala
+++ b/tyrian-platform/src/tyrian/platform/runtime/TyrianRuntime.scala
@@ -71,7 +71,7 @@ object TyrianRuntime:
     val initialDraw =
       present.draw(dispatcher, renderer, model, view, onMsg, router)(using F, clock)
 
-    initialDraw *> runCmd(initCmd) *> model.get.flatMap(m => runSub(subscriptions(m))) *> msgLoop
+    runCmd(initCmd) *> initialDraw *> model.get.flatMap(m => runSub(subscriptions(m))) *> msgLoop
 
   @SuppressWarnings(Array("scalafix:DisableSyntax.throw"))
   def runCommands[F[_], Msg](msgQueue: Queue[F, Msg])(cmd: Cmd[F, Msg])(using F: Async[F]): F[Unit] =

--- a/tyrian-sandboxes/sandbox-native-sdl/src-native/sandbox/TestSDLExtension.scala
+++ b/tyrian-sandboxes/sandbox-native-sdl/src-native/sandbox/TestSDLExtension.scala
@@ -45,6 +45,9 @@ object TestSDLExtension extends Extension.Graphical[SDLContext, TerminalFragment
   def watchers(model: ExtModel): Batch[Watcher] =
     Batch.empty
 
+  def prepare(model: ExtModel): Unit =
+    ()
+
   def teardown(model: ExtModel): Unit =
     ()
 

--- a/tyrian-sandboxes/sandbox-terminal/src/sandbox/SandboxTerminal.scala
+++ b/tyrian-sandboxes/sandbox-terminal/src/sandbox/SandboxTerminal.scala
@@ -40,6 +40,9 @@ object SandboxTerminal extends App[Unit, Model]:
   def extensions(args: List[String], model: Model): Set[Extension[Unit, TerminalFragment]] =
     Set()
 
+  def prepare: Unit =
+    println("Getting ready...")
+
   def teardown: Unit =
     println("Goodbye!")
 

--- a/tyrian-sandboxes/sandbox/src-js/example/CounterExtension.scala
+++ b/tyrian-sandboxes/sandbox/src-js/example/CounterExtension.scala
@@ -45,6 +45,9 @@ object CounterExtension extends Extension.Standard[HtmlFragment]:
   def watchers(currentValue: Int): Batch[Watcher] =
     Batch.empty
 
+  def prepare(currentValue: Int): Unit =
+    ()
+
   def teardown(currentValue: Int): Unit =
     ()
 

--- a/tyrian-shared/src/tyrian/extensions/Extension.scala
+++ b/tyrian-shared/src/tyrian/extensions/Extension.scala
@@ -38,6 +38,16 @@ sealed trait Extension[GraphicsContext, View]:
     */
   def watchers(model: ExtensionModel): Batch[Watcher]
 
+  /** Invoked once when terminal apps start up, guaranteed to run and complete before the first draw (has no effect on
+    * JS). Provides an opportunity for synchronous setup side-effects, such as putting the terminal into raw mode, so
+    * that the very first frame is rendered into a correctly prepared environment.
+    *
+    * `prepare` is the mirror of [[teardown]]: extensions are prepared before the main app's first draw and torn down
+    * before the main app exits. Like `teardown`, it has access to the extension's model so that references to resources
+    * acquired here can be retained for later clean up.
+    */
+  def prepare(model: ExtensionModel): Unit
+
   /** Invoked when terminal apps exit (has no effect on JS). Provides an opportunity for sign-off messages to the user,
     * or for clean up side-effects to take place.
     *

--- a/tyrian-shared/src/tyrian/extensions/ExtensionRegister.scala
+++ b/tyrian-shared/src/tyrian/extensions/ExtensionRegister.scala
@@ -115,6 +115,20 @@ final class ExtensionRegister[GraphicsContext, View](using m: Monoid[View]):
   def size: Int =
     registeredExtensions.length
 
+  def prepare: Unit =
+    registeredExtensions
+      .foreach: rss =>
+        val key       = rss.id
+        val extension = rss.extension
+
+        val model: extension.ExtensionModel =
+          stateMap.getUnsafe(key).asInstanceOf[extension.ExtensionModel]
+
+        try extension.prepare(model)
+        catch
+          case NonFatal(e) =>
+            println(s"Extension prepare failed [${key}]: ${e.getMessage}\n${e.getStackTrace().take(3).mkString("\n")}")
+
   def teardown: Unit =
     registeredExtensions
       .foreach: rss =>

--- a/tyrian-shared/test/src/tyrian/extensions/ExtensionRegisterTests.scala
+++ b/tyrian-shared/test/src/tyrian/extensions/ExtensionRegisterTests.scala
@@ -10,13 +10,29 @@ import scala.collection.mutable.ArrayBuffer
 @SuppressWarnings(Array("scalafix:DisableSyntax.var", "scalafix:DisableSyntax.throw"))
 class ExtensionRegisterTests extends munit.FunSuite {
 
+  test("prepare") {
+
+    var count = 0
+
+    val a = new TestExt("a", () => count = count + 1, () => ())
+    val b = new TestExt("b", () => throw new Exception("Ooops"), () => ())
+    val c = new TestExt("c", () => count = count + 1, () => ())
+
+    val register = new ExtensionRegister[Unit, TestView]()
+    val _        = register.register(Batch(a, b, c))
+
+    register.prepare
+
+    assertEquals(count, 2)
+  }
+
   test("teardown") {
 
     var count = 0
 
-    val a = new TestExt("a", () => count = count + 1)
-    val b = new TestExt("b", () => throw new Exception("Ooops"))
-    val c = new TestExt("c", () => count = count + 1)
+    val a = new TestExt("a", () => (), () => count = count + 1)
+    val b = new TestExt("b", () => (), () => throw new Exception("Ooops"))
+    val c = new TestExt("c", () => (), () => count = count + 1)
 
     val register = new ExtensionRegister[Unit, TestView]()
     val _        = register.register(Batch(a, b, c))
@@ -80,7 +96,7 @@ class ExtensionRegisterTests extends munit.FunSuite {
 
 }
 
-final class TestExt(_id: String, _teardown: () => Unit) extends Extension.Standard[TestView]:
+final class TestExt(_id: String, _prepare: () => Unit, _teardown: () => Unit) extends Extension.Standard[TestView]:
   type ExtensionModel = Unit
 
   def id: ExtensionId                            = ExtensionId(_id)
@@ -89,6 +105,7 @@ final class TestExt(_id: String, _teardown: () => Unit) extends Extension.Standa
   def view(m: Unit): TestView                    = TestView(Nil)
   def watchers(m: Unit): Batch[Watcher]          = Batch.empty
   def provideContext(m: Int): Option[Unit]       = None
+  def prepare(m: Unit): Unit                     = _prepare()
   def teardown(m: Unit): Unit                    = _teardown()
 
 final case class TestView(parts: List[String]) derives CanEqual
@@ -113,4 +130,5 @@ final class GraphicalRecorder(
     calls += ((ctx, t, m))
     m + 1
   def provideContext(m: Int): Option[TestCtx] = contextHook(m)
+  def prepare(m: Int): Unit                   = ()
   def teardown(m: Int): Unit                  = ()

--- a/tyrian-terminal/src/tyrian/internal/AppBase.scala
+++ b/tyrian-terminal/src/tyrian/internal/AppBase.scala
@@ -45,6 +45,18 @@ trait AppBase[GraphicsContext, Model] extends IOApp:
     */
   def extensions(args: List[String], model: Model): Set[Extension[GraphicsContext, TerminalFragment]]
 
+  /** Invoked once on start up, guaranteed to run and complete before the first draw. Provides an opportunity for
+    * synchronous setup side-effects, such as putting the terminal into raw mode, so that the very first frame is
+    * rendered into a correctly prepared environment.
+    *
+    * `prepare` is the mirror of [[teardown]]: the main app is prepared before any extensions and before the first draw,
+    * and torn down last on the way out. Like the main app `teardown`, `prepare` has no natural way to reach a model
+    * reference, so stateful setup is better placed in an extension's `prepare`.
+    *
+    * Note: `prepare` has no effect on the JS platform.
+    */
+  def prepare: Unit
+
   /** Invoked when terminal apps exit. Provides an opportunity for sign-off messages to the user, or for clean up
     * side-effects to take place.
     *
@@ -133,7 +145,13 @@ trait AppBase[GraphicsContext, Model] extends IOApp:
     def combinedSubscriptions(model: Model): Sub[IO, GlobalMsg] =
       _subscriptions(model) |+| Watcher.internal.Many(extensionsRegister.watchers).toSub
 
-    TyrianApp.start[IO, Model, GlobalMsg](
+    val prepareAll: IO[Unit] =
+      IO {
+        prepare
+        extensionsRegister.prepare
+      }
+
+    prepareAll *> TyrianApp.start[IO, Model, GlobalMsg](
       initModel -> (initCmds |+| Cmd.Batch(extensionsCmds.toList)),
       combinedUpdate,
       combinedView,


### PR DESCRIPTION

https://github.com/PurpleKingdomGames/indigoengine/issues/163

An initial attempt to resolve this by running init cmds first was doomed to fail because cmds are async. The use case for this ticket is being able to guarantee entry into RAW mode before the first draw (for example). To be fair, the first attempt felt wrong at the time!

The PR adds a `prepare` step that happens before anything else, it is the dual of the existing `teardown` process.