### PR TITLE
FIXED #185: BasicGameRuntime can now passes messages between Indigo & Tyrian

### DIFF
--- a/indigo-sandboxes/perf/src/com/example/perf/Runtime.scala
+++ b/indigo-sandboxes/perf/src/com/example/perf/Runtime.scala
@@ -1,11 +1,12 @@
 package com.example.perf
 
 import indigo.*
+import tyrian.*
 
 import scala.scalajs.js.annotation.*
 
 @JSExportTopLevel("IndigoGame")
-object Runtime extends BasicGameRuntime:
+object Runtime extends BasicGameRuntime[Unit]:
 
   def game: Game[?, ?, ?] =
     PerfGame()
@@ -14,3 +15,12 @@ object Runtime extends BasicGameRuntime:
     Settings.default
       .withFrameRatePolicy(FrameRatePolicy.Unlimited)
       .allowContextMenu
+
+  def eventMapping: PartialIso[GlobalMsg, GlobalEvent] =
+    PartialIso.none
+
+  def init(flags: Map[String, String]): Result[Unit] =
+    Result(())
+
+  def update(model: Unit): GlobalMsg => Result[Unit] =
+    case _ => Result(())

--- a/indigo-sandboxes/physics/src/example/Runtime.scala
+++ b/indigo-sandboxes/physics/src/example/Runtime.scala
@@ -1,11 +1,12 @@
 package example
 
 import indigo.*
+import tyrian.*
 
 import scala.scalajs.js.annotation.*
 
 @JSExportTopLevel("IndigoGame")
-object Runtime extends BasicGameRuntime:
+object Runtime extends BasicGameRuntime[Unit]:
 
   def game: Game[?, ?, ?] =
     IndigoPhysics()
@@ -13,3 +14,12 @@ object Runtime extends BasicGameRuntime:
   def settings: Settings =
     Settings.default
       .withFrameRatePolicy(FrameRatePolicy.Unlimited)
+
+  def eventMapping: PartialIso[GlobalMsg, GlobalEvent] =
+    PartialIso.none
+
+  def init(flags: Map[String, String]): Result[Unit] =
+    Result(())
+
+  def update(model: Unit): GlobalMsg => Result[Unit] =
+    case _ => Result(())

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/Runtime.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/Runtime.scala
@@ -1,11 +1,14 @@
 package com.example.sandbox
 
+import cats.effect.IO
 import indigo.*
+import tyrian.*
+import tyrian.classic.cmds.LocalStorage
 
 import scala.scalajs.js.annotation.*
 
 @JSExportTopLevel("IndigoGame")
-object Runtime extends BasicGameRuntime:
+object Runtime extends BasicGameRuntime[Unit]:
 
   def game: Game[?, ?, ?] =
     SandboxGame()
@@ -13,3 +16,60 @@ object Runtime extends BasicGameRuntime:
   def settings: Settings =
     Settings.default
       .withFrameRatePolicy(FrameRatePolicy.Skip(FPS.`60`))
+
+  def eventMapping: PartialIso[GlobalMsg, GlobalEvent] =
+    val to: GlobalMsg => Option[GlobalEvent] =
+      case StorageMsgs.Loaded(k, v) =>
+        Some(StorageEvents.Loaded(k, v))
+
+      case _ =>
+        None
+
+    val from: GlobalEvent => Option[GlobalMsg] =
+      case StorageEvents.Store(k, v) =>
+        Some(StorageMsgs.Store(k, v))
+
+      case StorageEvents.Load(k) =>
+        Some(StorageMsgs.Load(k))
+
+      case _ =>
+        None
+
+    PartialIso(to, from)
+
+  def init(flags: Map[String, String]): Result[Unit] =
+    Result(())
+
+  def update(model: Unit): GlobalMsg => Result[Unit] =
+    case StorageMsgs.Store(k, v) =>
+      Result(())
+        .addCmds(
+          LocalStorage.setItem[IO, GlobalMsg](k, v, _ => LogThis("Saved!"))
+        )
+
+    case StorageMsgs.Load(k) =>
+      val toMsg: Either[LocalStorage.Result.NotFound, LocalStorage.Result.Found] => GlobalMsg =
+        case Left(_) =>
+          LogThis(s"Not Found! Tried to load key '$k' from local storage.")
+
+        case Right(LocalStorage.Result.Found(data)) =>
+          StorageMsgs.Loaded(k, data)
+
+      Result(())
+        .addCmds(
+          LocalStorage.getItem[IO, GlobalMsg](k, toMsg)
+        )
+
+    case LogThis(msg) =>
+      Result(())
+        .log(msg)
+
+    case _ =>
+      Result(())
+
+enum StorageMsgs extends GlobalMsg:
+  case Store(key: String, value: String)
+  case Load(key: String)
+  case Loaded(key: String, value: String)
+
+final case class LogThis(msg: String) extends GlobalMsg

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/SandboxGame.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/SandboxGame.scala
@@ -94,12 +94,21 @@ final class SandboxGame extends Game[SandboxBootData, SandboxStartupData, Sandbo
 
   def initialModel(startupData: SandboxStartupData): Outcome[SandboxGameModel] =
     Outcome(SandboxModel.initialModel(startupData))
+      .addGlobalEvents(
+        StorageEvents.Store("test", "Hello, World!"),
+        StorageEvents.Load("test")
+      )
 
   def updateModel(
       context: Context,
       model: SandboxGameModel
   ): GlobalEvent => Outcome[SandboxGameModel] =
-    SandboxModelShared.updateModel(context, model)
+    case StorageEvents.Loaded(k, v) =>
+      IndigoLogger.info(s"Loaded [$k]: $v")
+      Outcome(model)
+
+    case e =>
+      SandboxModelShared.updateModel(context, model)(e)
 
   def present(
       context: Context,
@@ -139,3 +148,8 @@ final case class SandboxViewModel(
 )
 
 final case class Log(message: String) extends GlobalEvent
+
+enum StorageEvents extends GlobalEvent:
+  case Store(key: String, value: String)
+  case Load(key: String)
+  case Loaded(key: String, value: String)

--- a/indigo-sandboxes/shader/src/com/example/shader/Runtime.scala
+++ b/indigo-sandboxes/shader/src/com/example/shader/Runtime.scala
@@ -1,11 +1,12 @@
 package com.example.shader
 
 import indigo.*
+import tyrian.*
 
 import scala.scalajs.js.annotation.*
 
 @JSExportTopLevel("IndigoGame")
-object Runtime extends BasicGameRuntime:
+object Runtime extends BasicGameRuntime[Unit]:
 
   def game: Game[?, ?, ?] =
     ShaderGame()
@@ -13,3 +14,12 @@ object Runtime extends BasicGameRuntime:
   def settings: Settings =
     Settings.default
       .withFrameRatePolicy(FrameRatePolicy.Unlimited)
+
+  def eventMapping: PartialIso[GlobalMsg, GlobalEvent] =
+    PartialIso.none
+
+  def init(flags: Map[String, String]): Result[Unit] =
+    Result(())
+
+  def update(model: Unit): GlobalMsg => Result[Unit] =
+    case _ => Result(())

--- a/indigo/src-js/indigo/BasicGameRuntime.scala
+++ b/indigo/src-js/indigo/BasicGameRuntime.scala
@@ -29,7 +29,7 @@ trait BasicGameRuntime[Model] extends App[WebGL2Context, Model]:
 
   /** Defines a partial two-way mapping of Indigo GlobalEvents and Tyrian GlobalMsgs. For example, if you want to save
     * your game you emit a GlobalEvent in Indigo, this mapping sees the event, and translates it to a GlobalMsg that can
-    * be matched in the [[updateModel]] function, you can then acknowledge the save by reversing the process.
+    * be matched in the [[update]] function, you can then acknowledge the save by reversing the process.
     */
   def eventMapping: PartialIso[GlobalMsg, GlobalEvent]
 

--- a/indigo/src-js/indigo/BasicGameRuntime.scala
+++ b/indigo/src-js/indigo/BasicGameRuntime.scala
@@ -4,19 +4,39 @@ import indigo.*
 import tyrian.*
 import tyrian.ui.*
 
-/** Provides a no-frills Tyrian runtime for a single running Indigo game. For anything more complicated, you'll want to
-  * build your own.
+/** Provides a no-frills cut-down Tyrian runtime for running a single Indigo game. Its goal is to be uncomplicated while
+  * offering a basic useful level of functionality.
+  *
+  * For anything more complicated, for instance if you want specific control over the view the game is drawn into, then
+  * you'll want to build your own.
+  *
+  * The `Model` can be anything you wish, and only exists at the level of this runtime / Tyrian app. Your game cannot
+  * see it directly.
+  *
+  * This runtime and your game can communicate by translating `GlobalEvent <-> GlobalMsg` and vice versa, and handling
+  * those messages in the respective update functions. This allows you to ask the runtime to handle side effecting
+  * operations such as HTTP requests and local storage, and to send relevant data back to your game once completed.
   */
-trait BasicGameRuntime extends App[WebGL2Context, Unit]:
+trait BasicGameRuntime[Model] extends App[WebGL2Context, Model]:
 
+  /** Kicks off an instance of your game.
+    */
   def game: Game[?, ?, ?]
 
+  /** Used to define your game's platform settings, such as the frame rate policy.
+    */
   def settings: Settings
+
+  /** Defines a partial two-way mapping of Indigo GlobalEvents and Tyrian GlobalMsgs. For example, if you want to save
+    * your game you emit a GlobalEvent in Indigo, this mapping sees the event, and translates it to a GlobalMsg that can
+    * be matched in the [[updateModel]] function, you can then acknowledge the save by reversing the process.
+    */
+  def eventMapping: PartialIso[GlobalMsg, GlobalEvent]
 
   private val containerMarkerId = MarkerId("indigo-game-container")
   private given Theme           = Theme.None
 
-  def extensions(flags: Map[String, String], model: Unit): Set[Extension[WebGL2Context, HtmlFragment]] =
+  def extensions(flags: Map[String, String], model: Model): Set[Extension[WebGL2Context, HtmlFragment]] =
     Set(
       Indigo(
         ExtensionId("indigo game"),
@@ -24,26 +44,13 @@ trait BasicGameRuntime extends App[WebGL2Context, Unit]:
         game,
         containerMarkerId
       ).withSettings(settings)
+        .withEventMapping(eventMapping)
     )
 
-  def init(flags: Map[String, String]): Result[Unit] =
-    Result(())
-
   def router: Location => GlobalMsg =
-    Routing.none(AppMsg.NoOp)
+    Routing.none(RoutingDisabled.default)
 
-  def update(model: Unit): GlobalMsg => Result[Unit] =
-    case m: AppMsg =>
-      handleAppMsg(model)(m)
-
-    case _ =>
-      Result(model)
-
-  def handleAppMsg(model: Unit): AppMsg => Result[Unit] =
-    case AppMsg.NoOp =>
-      Result(model)
-
-  def view(model: Unit): HtmlRoot =
+  def view(model: Model): HtmlRoot =
     val surround: Batch[Elem[GlobalMsg]] => Html[GlobalMsg] =
       elems =>
         Container(
@@ -64,8 +71,10 @@ trait BasicGameRuntime extends App[WebGL2Context, Unit]:
 
     HtmlRoot(surround, fragment)
 
-  def watchers(model: Unit): Batch[Watcher] =
+  def watchers(model: Model): Batch[Watcher] =
     Batch.empty
 
-enum AppMsg extends GlobalMsg:
-  case NoOp
+final case class RoutingDisabled(reason: String) extends GlobalMsg
+object RoutingDisabled:
+  val default: RoutingDisabled =
+    RoutingDisabled("Routing is not used in the BasicGameRuntime.")

--- a/roguelike-starterkit-demo/src/demo/Runtime.scala
+++ b/roguelike-starterkit-demo/src/demo/Runtime.scala
@@ -1,11 +1,12 @@
 package demo
 
 import indigo.*
+import tyrian.*
 
 import scala.scalajs.js.annotation.*
 
 @JSExportTopLevel("IndigoGame")
-object Runtime extends BasicGameRuntime:
+object Runtime extends BasicGameRuntime[Unit]:
 
   def game: Game[?, ?, ?] =
     RogueLikeGame()
@@ -13,3 +14,12 @@ object Runtime extends BasicGameRuntime:
   def settings: Settings =
     Settings.default
       .withFrameRatePolicy(FrameRatePolicy.Unlimited)
+
+  def eventMapping: PartialIso[GlobalMsg, GlobalEvent] =
+    PartialIso.none
+
+  def init(flags: Map[String, String]): Result[Unit] =
+    Result(())
+
+  def update(model: Unit): GlobalMsg => Result[Unit] =
+    case _ => Result(())

--- a/ultraviolet-sandbox/src/com/example/sandbox/Runtime.scala
+++ b/ultraviolet-sandbox/src/com/example/sandbox/Runtime.scala
@@ -1,11 +1,12 @@
 package com.example.sandbox
 
 import indigo.*
+import tyrian.*
 
 import scala.scalajs.js.annotation.*
 
 @JSExportTopLevel("IndigoGame")
-object Runtime extends BasicGameRuntime:
+object Runtime extends BasicGameRuntime[Unit]:
 
   def game: Game[?, ?, ?] =
     SandboxGame()
@@ -13,3 +14,12 @@ object Runtime extends BasicGameRuntime:
   def settings: Settings =
     Settings.default
       .withFrameRatePolicy(FrameRatePolicy.Unlimited)
+
+  def eventMapping: PartialIso[GlobalMsg, GlobalEvent] =
+    PartialIso.none
+
+  def init(flags: Map[String, String]): Result[Unit] =
+    Result(())
+
+  def update(model: Unit): GlobalMsg => Result[Unit] =
+    case _ => Result(())


### PR DESCRIPTION
This PR resolves https://github.com/PurpleKingdomGames/indigoengine/issues/185 by expanding the interface of BasicGameRuntime.

It's a breaking change, but since the releases are currently in the 'milestone' stage, that isn't a concern.

BasicGameRuntime now has a real Model so that you can store data if desired, but more importantly, it now exposes the event mapping process so that you can seamlessly transfer messages from Indigo to Tyrian and back again.

In the demo in this PR, Indigo asks Tyrian to save a message and then instantly loads it again, also via Tyrian.