### PR TITLE
FIXED #195: Graphics with crops defined where not behaving with the various fill types

### DIFF
--- a/indigo-core/src/indigo/core/datatypes/Point.scala
+++ b/indigo-core/src/indigo/core/datatypes/Point.scala
@@ -79,8 +79,10 @@ final case class Point(x: Int, y: Int) derives CanEqual:
   def distanceTo(other: Point): Double =
     Point.distanceBetween(this, other)
 
-  def toVector: Vector2 =
+  def toVector2: Vector2 =
     Vector2(x.toDouble, y.toDouble)
+  def toVector: Vector2 =
+    toVector2
 
   def toSize: Size =
     Size(x, y)

--- a/indigo-core/src/indigo/core/datatypes/Size.scala
+++ b/indigo-core/src/indigo/core/datatypes/Size.scala
@@ -47,8 +47,10 @@ final case class Size(width: Int, height: Int) derives CanEqual:
   def resizeBy(width: Int, height: Int): Size =
     resizeBy(Size(width, height))
 
-  def toVector: Vector2 =
+  def toVector2: Vector2 =
     Vector2(width.toDouble, height.toDouble)
+  def toVector: Vector2 =
+    toVector2
 
   def toPoint: Point =
     Point(width, height)

--- a/indigo-extras/src/indigoextras/effectmaterials/shaders/LegacyEffectsShaders.scala
+++ b/indigo-extras/src/indigoextras/effectmaterials/shaders/LegacyEffectsShaders.scala
@@ -269,7 +269,7 @@ object LegacyEffectsShaders:
         // ----------------------------------
         // Identical to ImageEffects (start)
 
-        // 0 = normal 1 = stretch 2 = tile
+        // 0 = normal, 1 = stretch, 2 = tile, 3 = nine-slice
         val fillType: Int =
           round(env.ALPHA_SATURATION_OVERLAYTYPE_FILLTYPE.w).toInt
 

--- a/indigo-extras/src/indigoextras/effectmaterials/shaders/LegacyEffectsShaders.scala
+++ b/indigo-extras/src/indigoextras/effectmaterials/shaders/LegacyEffectsShaders.scala
@@ -112,7 +112,7 @@ object LegacyEffectsShaders:
         calculateRadialGradientOverlay
       val _calculateSaturation: (vec4, Float) => vec4 =
         calculateSaturation
-      val _tileAndStretchChannel: (Int, vec4, sampler2D.type, vec2, vec2, vec2, vec2, vec2, vec4) => vec4 =
+      val _tileAndStretchChannel: (Int, sampler2D.type, vec2, vec2, vec2, vec2, vec2, vec4) => vec4 =
         tileAndStretchChannel
 
       @in val v_offsetTL: vec2 = null
@@ -275,7 +275,6 @@ object LegacyEffectsShaders:
 
         env.CHANNEL_0 = _tileAndStretchChannel(
           fillType,
-          env.CHANNEL_0,
           env.SRC_CHANNEL,
           env.CHANNEL_0_POSITION,
           env.CHANNEL_0_SIZE,
@@ -286,7 +285,6 @@ object LegacyEffectsShaders:
         )
         env.CHANNEL_1 = _tileAndStretchChannel(
           fillType,
-          env.CHANNEL_1,
           env.SRC_CHANNEL,
           env.CHANNEL_1_POSITION,
           env.CHANNEL_0_SIZE,
@@ -297,7 +295,6 @@ object LegacyEffectsShaders:
         )
         env.CHANNEL_2 = _tileAndStretchChannel(
           fillType,
-          env.CHANNEL_2,
           env.SRC_CHANNEL,
           env.CHANNEL_2_POSITION,
           env.CHANNEL_0_SIZE,
@@ -308,7 +305,6 @@ object LegacyEffectsShaders:
         )
         env.CHANNEL_3 = _tileAndStretchChannel(
           fillType,
-          env.CHANNEL_3,
           env.SRC_CHANNEL,
           env.CHANNEL_3_POSITION,
           env.CHANNEL_0_SIZE,

--- a/indigo-extras/src/indigoextras/effectmaterials/shaders/RefractionShaders.scala
+++ b/indigo-extras/src/indigoextras/effectmaterials/shaders/RefractionShaders.scala
@@ -47,7 +47,7 @@ object RefractionShaders:
       import TileAndStretch.*
 
       // Delegates
-      val _tileAndStretchChannel: (Int, vec4, sampler2D.type, vec2, vec2, vec2, vec2, vec2, vec4) => vec4 =
+      val _tileAndStretchChannel: (Int, sampler2D.type, vec2, vec2, vec2, vec2, vec2, vec4) => vec4 =
         tileAndStretchChannel
 
       ubo[IndigoBitmapData]
@@ -56,7 +56,6 @@ object RefractionShaders:
 
         env.CHANNEL_0 = _tileAndStretchChannel(
           env.FILLTYPE.toInt,
-          env.CHANNEL_0,
           env.SRC_CHANNEL,
           env.CHANNEL_0_POSITION,
           env.CHANNEL_0_SIZE,
@@ -67,7 +66,6 @@ object RefractionShaders:
         )
         env.CHANNEL_1 = _tileAndStretchChannel(
           env.FILLTYPE.toInt,
-          env.CHANNEL_1,
           env.SRC_CHANNEL,
           env.CHANNEL_1_POSITION,
           env.CHANNEL_0_SIZE,
@@ -78,7 +76,6 @@ object RefractionShaders:
         )
         env.CHANNEL_2 = _tileAndStretchChannel(
           env.FILLTYPE.toInt,
-          env.CHANNEL_2,
           env.SRC_CHANNEL,
           env.CHANNEL_2_POSITION,
           env.CHANNEL_0_SIZE,
@@ -89,7 +86,6 @@ object RefractionShaders:
         )
         env.CHANNEL_3 = _tileAndStretchChannel(
           env.FILLTYPE.toInt,
-          env.CHANNEL_3,
           env.SRC_CHANNEL,
           env.CHANNEL_3_POSITION,
           env.CHANNEL_0_SIZE,

--- a/indigo-platform/src/indigo/shared/formats/TileSheet.scala
+++ b/indigo-platform/src/indigo/shared/formats/TileSheet.scala
@@ -36,7 +36,7 @@ final case class TileSheet(
       Graphic(
         bounds.size,
         Material.Bitmap(assetName)
-      )
+      ).withCrop(bounds)
     }
 
   /** @param index

--- a/indigo-platform/src/indigo/shared/formats/TileSheet.scala
+++ b/indigo-platform/src/indigo/shared/formats/TileSheet.scala
@@ -34,8 +34,8 @@ final case class TileSheet(
   def graphicFromRectangle(boundsOpt: Option[Rectangle]): Option[Graphic[Material.Bitmap]] =
     boundsOpt.map { bounds =>
       Graphic(
-        bounds = bounds,
-        material = Material.Bitmap(assetName)
+        bounds.size,
+        Material.Bitmap(assetName)
       )
     }
 

--- a/indigo-platform/src/indigo/shared/formats/TiledMap.scala
+++ b/indigo-platform/src/indigo/shared/formats/TiledMap.scala
@@ -128,7 +128,7 @@ object TiledMap {
             layer.data.toSet.foldLeft(Map.empty[Int, Graphic[Material.Bitmap]]) { (tiles, i) =>
               tiles ++ Map(
                 i ->
-                  Graphic(Rectangle(Point.zero, tileSize), Material.Bitmap(assetName))
+                  Graphic(tileSize, Material.Bitmap(assetName))
                     .withCrop(
                       Rectangle(fromIndex(i - 1, tileSheetColumnCount) * tileSize.toPoint, tileSize)
                     )

--- a/indigo-render-pipeline/src/indigo/render/pipeline/displayprocessing/utils/GraphicConversion.scala
+++ b/indigo-render-pipeline/src/indigo/render/pipeline/displayprocessing/utils/GraphicConversion.scala
@@ -1,5 +1,6 @@
 package indigo.render.pipeline.displayprocessing.utils
 
+import indigo.core.datatypes.Rectangle
 import indigo.core.datatypes.Vector2
 import indigo.core.utils.QuickCache
 import indigo.render.pipeline.assets.AssetMapping
@@ -28,13 +29,26 @@ object GraphicConversion:
     val normalOffset   = TextureLookups.findAssetOffsetValues(assetMapping, shaderData.channel2, shaderDataHash, "_n")
     val specularOffset = TextureLookups.findAssetOffsetValues(assetMapping, shaderData.channel3, shaderDataHash, "_s")
 
-    val texture = TextureLookups.lookupTexture(assetMapping, materialName)
+    val texture =
+      val t = TextureLookups.lookupTexture(assetMapping, materialName)
+
+      leaf.crop match
+        case None =>
+          t
+
+        case Some(c) =>
+          t.copy(
+            offset = t.offset + c.position.toVector2,
+            size = c.size.toVector2
+          )
 
     val frameInfo =
-      QuickCache(s"${leaf.crop.hashCode().toString}_$shaderDataHash") {
+      QuickCache(
+        s"${leaf.size.hashCode().toString}_${leaf.crop.map(_.hashCode().toString).getOrElse("-")}_$shaderDataHash"
+      ) {
         SpriteSheetFrame.calculateFrameOffset(
           atlasSize = texture.atlasSize,
-          frameCrop = leaf.crop,
+          frameCrop = Rectangle(leaf.size),
           textureOffset = texture.offset
         )
       }
@@ -54,8 +68,8 @@ object GraphicConversion:
       flipX = if leaf.flip.horizontal then -1.0 else 1.0,
       flipY = if leaf.flip.vertical then -1.0 else 1.0,
       rotation = leaf.rotation,
-      width = leaf.crop.size.width,
-      height = leaf.crop.size.height,
+      width = leaf.size.width,
+      height = leaf.size.height,
       atlasName = Some(texture.atlasName),
       frame = frameInfo,
       channelOffset1 = frameInfo.offsetToCoords(emissiveOffset),

--- a/indigo-render-pipeline/test/src/indigo/render/pipeline/displayprocessing/DisplayObjectConversionsTests.scala
+++ b/indigo-render-pipeline/test/src/indigo/render/pipeline/displayprocessing/DisplayObjectConversionsTests.scala
@@ -1,7 +1,7 @@
 package indigo.render.pipeline.displayprocessing
 
 import indigo.core.assets.AssetName
-import indigo.core.datatypes.Rectangle
+import indigo.core.datatypes.Size
 import indigo.core.datatypes.Vector2
 import indigo.core.events.GlobalEvent
 import indigo.core.time.GameTime
@@ -28,7 +28,8 @@ import indigoengine.shared.datatypes.Seconds
 class DisplayObjectConversionsTests extends munit.FunSuite {
 
   val graphic: Graphic[?] =
-    Graphic(Rectangle(10, 20, 200, 100), Material.Bitmap(AssetName("texture")))
+    Graphic(Size(200, 100), Material.Bitmap(AssetName("texture")))
+      .moveTo(10, 20)
 
   val animationRegister = new AnimationsRegister
   val fontRegister      = new FontRegister

--- a/indigo-render-pipeline/test/src/indigo/render/pipeline/sceneprocessing/SceneProcessorTests.scala
+++ b/indigo-render-pipeline/test/src/indigo/render/pipeline/sceneprocessing/SceneProcessorTests.scala
@@ -2,6 +2,7 @@ package indigo.render.pipeline.sceneprocessing
 
 import indigo.core.assets.AssetName
 import indigo.core.datatypes.Rectangle
+import indigo.core.datatypes.Size
 import indigo.core.datatypes.Vector2
 import indigo.core.events.GlobalEvent
 import indigo.core.time.GameTime
@@ -45,7 +46,7 @@ class SceneProcessorTests extends munit.FunSuite {
     )
 
   test("makeDisplayLayers - single layer with one graphic") {
-    val graphic = Graphic(Rectangle(10, 20, 200, 100), Material.Bitmap(AssetName("texture")))
+    val graphic = Graphic(Size(200, 100), Material.Bitmap(AssetName("texture"))).withCrop(Rectangle(10, 20, 200, 100))
     val scene   = SceneUpdateFragment(graphic)
 
     val result = SceneProcessor.makeDisplayLayers(
@@ -65,8 +66,8 @@ class SceneProcessorTests extends munit.FunSuite {
   }
 
   test("makeDisplayLayers - two separate layers") {
-    val graphic1 = Graphic(Rectangle(0, 0, 50, 50), Material.Bitmap(AssetName("texture")))
-    val graphic2 = Graphic(Rectangle(100, 100, 50, 50), Material.Bitmap(AssetName("texture")))
+    val graphic1 = Graphic(Size(50), Material.Bitmap(AssetName("texture"))).withCrop(Rectangle(0, 0, 50, 50))
+    val graphic2 = Graphic(Size(50), Material.Bitmap(AssetName("texture"))).withCrop(Rectangle(100, 100, 50, 50))
     val scene = SceneUpdateFragment(
       Layer(graphic1),
       Layer(graphic2)

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/SandboxGame.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/SandboxGame.scala
@@ -13,7 +13,7 @@ final class SandboxGame extends Game[SandboxBootData, SandboxStartupData, Sandbo
   val gameId: GameId = GameId("sandbox")
 
   def initialScene(bootData: SandboxBootData): Option[SceneName] =
-    Some(BgAudioScene.name)
+    Some(NineSliceScene.name)
 
   def scenes(bootData: SandboxBootData): NonEmptyBatch[Scene[SandboxGameModel]] =
     ScenesList.scenes

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/BoundsScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/BoundsScene.scala
@@ -38,7 +38,7 @@ object BoundsScene extends Scene[SandboxGameModel]:
     val speed = 0.25
 
     val graphic: Graphic[Material.Bitmap] =
-      Graphic(Rectangle(0, 0, 40, 40), BoundsAssets.junctionBoxMaterialOff)
+      Graphic(40, 40, BoundsAssets.junctionBoxMaterialOff)
         .moveTo(SandboxGame.screenCenter)
         .rotateTo(Radians.fromSeconds(context.frame.time.running * speed))
 
@@ -86,8 +86,8 @@ object BoundsScene extends Scene[SandboxGameModel]:
 
     val group: Group =
       Group(
-        Graphic(Rectangle(0, 0, 40, 40), BoundsAssets.junctionBoxMaterialOff),
-        Graphic(Rectangle(0, 0, 40, 40), BoundsAssets.junctionBoxMaterialOff).moveBy(15, 15)
+        Graphic(40, 40, BoundsAssets.junctionBoxMaterialOff),
+        Graphic(40, 40, BoundsAssets.junctionBoxMaterialOff).moveBy(15, 15)
       )
         .moveTo(200, 120)
         .rotateTo(Radians.fromSeconds(context.frame.time.running * speed))

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/CameraScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/CameraScene.scala
@@ -44,7 +44,7 @@ object CameraScene extends Scene[SandboxGameModel] {
       SceneUpdateFragment(
         Layer(
           Graphic(
-            Rectangle(Point.zero, (SandboxGame.screenCenter * 4).toSize),
+            (SandboxGame.screenCenter * 4).toSize,
             SandboxAssets.foliageMaterial
           ),
           Graphic(32, 32, Material.Bitmap(SandboxAssets.dots)).moveTo(-16, -16)

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/CaptureScreenScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/CaptureScreenScene.scala
@@ -102,20 +102,20 @@ object CaptureScreenScene extends Scene[SandboxGameModel]:
       SceneUpdateFragment(
         uiKey -> Layer(
           Batch(
-            Graphic(Rectangle(0, 0, 16, 16), Material.Bitmap(SandboxAssets.cameraIcon)).moveTo(250, 165),
+            Graphic(16, 16, Material.Bitmap(SandboxAssets.cameraIcon)).moveTo(250, 165),
             Shape.Box(clippingRect, Fill.None, Stroke(1, RGBA.SlateGray))
           ) ++ ((model.captureScreenScene.screenshot1, model.captureScreenScene.screenshot2) match {
             case (Some(image1), Some(image2)) =>
               Batch(
                 Graphic(
-                  Rectangle(viewPort),
+                  viewPort,
                   Material.Bitmap(image1)
                 ).scaleBy(Vector2(screenshotScale))
                   .moveTo(viewPort.width - (viewPort.width * screenshotScale).toInt - 5, 5),
                 Box(bigRect, Fill.None, Stroke(1, RGBA.Black))
                   .moveTo(viewPort.width - (viewPort.width * screenshotScale).toInt - 5, 5),
                 Graphic(
-                  clippingRect,
+                  clippingRect.size,
                   Material.Bitmap(image2)
                 ).scaleBy(Vector2(screenshotScale))
                   .moveTo(

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/LegacyEffectsScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/LegacyEffectsScene.scala
@@ -33,7 +33,7 @@ object LegacyEffectsScene extends Scene[SandboxGameModel] {
     _ => Outcome(model)
 
   val graphic: Graphic[LegacyEffects] =
-    Graphic(Rectangle(0, 0, 40, 40), SandboxAssets.junctionBoxEffectsMaterial)
+    Graphic(40, 40, SandboxAssets.junctionBoxEffectsMaterial)
       .withRef(20, 20)
 
   def present(

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/LightsScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/LightsScene.scala
@@ -28,7 +28,7 @@ object LightsScene extends Scene[SandboxGameModel] {
     _ => Outcome(model)
 
   val graphic: Graphic[Material.Bitmap] =
-    Graphic(Rectangle(0, 0, 40, 40), LightingAssets.junctionBoxMaterialOn)
+    Graphic(40, 40, LightingAssets.junctionBoxMaterialOn)
       .withCrop(0, 0, 275, 200)
       .modifyMaterial(_.withFillType(FillType.Tile))
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/LightsScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/LightsScene.scala
@@ -28,8 +28,7 @@ object LightsScene extends Scene[SandboxGameModel] {
     _ => Outcome(model)
 
   val graphic: Graphic[Material.Bitmap] =
-    Graphic(40, 40, LightingAssets.junctionBoxMaterialOn)
-      .withCrop(0, 0, 275, 200)
+    Graphic(275, 200, LightingAssets.junctionBoxMaterialOn)
       .modifyMaterial(_.withFillType(FillType.Tile))
 
   val graphic2: Graphic[Material.ImageEffects] =
@@ -70,7 +69,7 @@ object LightsScene extends Scene[SandboxGameModel] {
           DirectionLight(RGBA.Cyan.withAmount(0.1), RGBA.Cyan, Radians.zero),
           PointLight.default
             .withSpecular(RGBA.White)
-            .moveTo(context.frame.input.mouse.position)
+            .moveTo(context.frame.input.mouse.position / 2)
             .withColor(RGBA.Red.mix(RGBA.White, 0.1))
             .withIntensity(2)
             .withFalloff(Falloff.smoothQuadratic.withRange(0, 80)),

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/NineSliceScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/NineSliceScene.scala
@@ -4,6 +4,7 @@ import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGameModel
 import indigo.*
 import indigo.scenes.*
+import indigo.syntax.*
 
 object NineSliceScene extends Scene[SandboxGameModel] {
 
@@ -38,35 +39,62 @@ object NineSliceScene extends Scene[SandboxGameModel] {
   ): Outcome[SceneUpdateFragment] = {
     val boxSizeValue: Int = boxSize(context.frame.time.running)
 
+    val graphic =
+      Graphic(64, 64, Material.Bitmap(SandboxAssets.cratesDiffuseName))
+
+    def crate(gg: Graphic[Material.Bitmap])(position: Point): Batch[SceneNode] =
+      Batch(
+        gg.moveTo(position).withSize(Size(boxSizeValue)),
+        Shape
+          .Box(Rectangle(boxSizeValue, boxSizeValue), Fill.None, Stroke(1, RGBA.Green))
+          .moveTo(position)
+      )
+
+    def crateStyles(gg: Graphic[Material.Bitmap], ps: Batch[Point], doNineSlice: Boolean): Batch[SceneNode] =
+      val skip: Point => Batch[SceneNode] = _ => Batch.empty
+      Batch(
+        crate(gg),
+        crate(gg.modifyMaterial(_.tile)),
+        crate(gg.modifyMaterial(_.stretch)),
+        if doNineSlice then crate(gg.modifyMaterial(_.nineSlice(Rectangle(5, 5, 24, 40))))
+        else skip
+      ).zip(ps)
+        .flatMap: (c, p) =>
+          c(p)
+
     Outcome(
       SceneUpdateFragment.empty
         .addLayers(
           Layer(
-            Graphic(
-              boxSizeValue,
-              boxSizeValue,
-              Material.Bitmap(SandboxAssets.nineSlice).nineSlice(Rectangle(16, 16, 32, 32))
-            ).moveTo(5, 5),
-            // Shape
-            //   .Box(Rectangle(boxSizeValue, boxSizeValue), Fill.None, Stroke(1, RGBA.Green))
-            //   .moveTo(5, 5),
-            Graphic(
-              boxSizeValue,
-              boxSizeValue,
-              Material.Bitmap(SandboxAssets.platform).nineSlice(Rectangle(8, 20, 112, 40))
-            ).moveTo(100, 5),
-            // Shape
-            //   .Box(Rectangle(boxSizeValue, boxSizeValue), Fill.None, Stroke(1, RGBA.Green))
-            //   .moveTo(75, 5),
-            Graphic(
-              boxSizeValue,
-              boxSizeValue,
-              Material.Bitmap(SandboxAssets.window).nineSlice(Rectangle(3, 15, 121, 41))
-            ).moveTo(5, 100)
-            // Shape
-            //   .Box(Rectangle(boxSizeValue, boxSizeValue), Fill.None, Stroke(1, RGBA.Green))
-            //   .moveTo(5, 75),
-          )
+            Batch(
+              Graphic(
+                boxSizeValue,
+                boxSizeValue,
+                Material.Bitmap(SandboxAssets.nineSlice).nineSlice(Rectangle(16, 16, 32, 32))
+              ).moveTo(5, 5),
+              // Shape
+              //   .Box(Rectangle(boxSizeValue, boxSizeValue), Fill.None, Stroke(1, RGBA.Green))
+              //   .moveTo(5, 5),
+              Graphic(
+                boxSizeValue,
+                boxSizeValue,
+                Material.Bitmap(SandboxAssets.platform).nineSlice(Rectangle(8, 20, 112, 40))
+              ).moveTo(100, 5),
+              // Shape
+              //   .Box(Rectangle(boxSizeValue, boxSizeValue), Fill.None, Stroke(1, RGBA.Green))
+              //   .moveTo(100, 5),
+              Graphic(
+                boxSizeValue,
+                boxSizeValue,
+                Material.Bitmap(SandboxAssets.window).nineSlice(Rectangle(3, 15, 121, 41))
+              ).moveTo(5, 100)
+              // Shape
+              //   .Box(Rectangle(boxSizeValue, boxSizeValue), Fill.None, Stroke(1, RGBA.Green))
+              //   .moveTo(5, 100),
+            ) ++
+              crateStyles(graphic, (0 until 4).toBatch.map(col => Point(col * 100, 200)), false) ++
+              crateStyles(graphic.withCrop(32, 0, 32, 48), (0 until 4).toBatch.map(col => Point(col * 100, 300)), true)
+          ).withMagnificationForAll(2)
         )
     )
   }

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/RefractionScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/RefractionScene.scala
@@ -31,20 +31,20 @@ object RefractionScene extends Scene[SandboxGameModel] {
     _ => Outcome(model)
 
   val graphic: Graphic[Material.Bitmap] =
-    Graphic(Rectangle(0, 0, 64, 64), SandboxAssets.junctionBoxMaterial)
+    Graphic(64, 64, SandboxAssets.junctionBoxMaterial)
       .withRef(20, 20)
 
   val imageLight: Graphic[Material.Bitmap] =
-    Graphic(Rectangle(0, 0, 320, 240), SandboxAssets.imageLightMaterial)
+    Graphic(320, 240, SandboxAssets.imageLightMaterial)
       .moveBy(-14, -60)
 
   val distortion: Graphic[RefractionEntity] =
-    Graphic(Rectangle(0, 0, 240, 240), SandboxAssets.normalMapMaterial)
+    Graphic(240, 240, SandboxAssets.normalMapMaterial)
       .scaleBy(0.5, 0.5)
       .withRef(120, 120)
 
   val background: Graphic[Material.Bitmap] =
-    Graphic(Rectangle(0, 0, 790, 380), SandboxAssets.foliageMaterial)
+    Graphic(790, 380, SandboxAssets.foliageMaterial)
 
   def sliding: Signal[Graphic[RefractionEntity]] =
     Signal.SmoothPulse.map { d =>

--- a/indigo-sandboxes/sandbox/src/main/scala/com/example/sandbox/SandboxAssets.scala
+++ b/indigo-sandboxes/sandbox/src/main/scala/com/example/sandbox/SandboxAssets.scala
@@ -46,10 +46,14 @@ object SandboxAssets:
 
   val colouredDots: Graphic[Material.Bitmap] = Graphic(32, 32, Material.Bitmap(dots))
 
-  val redDot: Graphic[Material.Bitmap]    = Graphic(Rectangle(0, 0, 16, 16), Material.Bitmap(dots)).withRef(8, 8)
-  val greenDot: Graphic[Material.Bitmap]  = Graphic(Rectangle(16, 0, 16, 16), Material.Bitmap(dots)).withRef(8, 8)
-  val blueDot: Graphic[Material.Bitmap]   = Graphic(Rectangle(0, 16, 16, 16), Material.Bitmap(dots)).withRef(8, 8)
-  val yellowDot: Graphic[Material.Bitmap] = Graphic(Rectangle(16, 16, 16, 16), Material.Bitmap(dots)).withRef(8, 8)
+  val redDot: Graphic[Material.Bitmap] =
+    Graphic(Size(16), Material.Bitmap(dots)).withRef(8, 8).withCrop(Rectangle(0, 0, 16, 16))
+  val greenDot: Graphic[Material.Bitmap] =
+    Graphic(Size(16), Material.Bitmap(dots)).withRef(8, 8).withCrop(Rectangle(16, 0, 16, 16))
+  val blueDot: Graphic[Material.Bitmap] =
+    Graphic(Size(16), Material.Bitmap(dots)).withRef(8, 8).withCrop(Rectangle(0, 16, 16, 16))
+  val yellowDot: Graphic[Material.Bitmap] =
+    Graphic(Size(16), Material.Bitmap(dots)).withRef(8, 8).withCrop(Rectangle(16, 16, 16, 16))
 
   val junctionBoxAlbedo: AssetName    = AssetName("junctionbox_albedo")
   val junctionBoxEmission: AssetName  = AssetName("junctionbox_emission")

--- a/indigo-scenegraph/src/indigo/scenegraph/Clip.scala
+++ b/indigo-scenegraph/src/indigo/scenegraph/Clip.scala
@@ -192,6 +192,7 @@ final case class Clip[M <: Material](
           )
 
     Graphic(
+      size = size,
       eventHandlerEnabled = false,
       eventHandler = Function.const(None),
       position = position,
@@ -199,7 +200,7 @@ final case class Clip[M <: Material](
       scale = scale,
       ref = ref,
       flip = flip,
-      crop = Rectangle(framePositon * size.toPoint, size),
+      crop = Some(Rectangle(framePositon * size.toPoint, size)),
       material = material
     )
 

--- a/indigo-scenegraph/src/indigo/scenegraph/Graphic.scala
+++ b/indigo-scenegraph/src/indigo/scenegraph/Graphic.scala
@@ -16,7 +16,8 @@ import indigoengine.shared.datatypes.Radians
   */
 final case class Graphic[M <: Material](
     material: M,
-    crop: Rectangle,
+    size: Size,
+    crop: Option[Rectangle],
     eventHandlerEnabled: Boolean,
     eventHandler: ((Graphic[?], GlobalEvent)) => Option[GlobalEvent],
     position: Point,
@@ -32,10 +33,7 @@ final case class Graphic[M <: Material](
     visitor.visitGraphic(this)
 
   def bounds: Rectangle =
-    BoundaryLocator.findBounds(this, position, crop.size, ref)
-
-  lazy val size: Size =
-    crop.size
+    BoundaryLocator.findBounds(this, position, size, ref)
 
   lazy val x: Int = position.x
   lazy val y: Int = position.y
@@ -90,8 +88,20 @@ final case class Graphic[M <: Material](
   def withRef(x: Int, y: Int): Graphic[M] =
     withRef(Point(x, y))
 
+  def withSize(newSize: Size): Graphic[M] =
+    this.copy(size = newSize)
+  def resizeTo(newSize: Size): Graphic[M] =
+    withSize(newSize)
+  def resizeTo(width: Int, height: Int): Graphic[M] =
+    resizeTo(Size(width, height))
+
+  def resizeBy(amount: Size): Graphic[M] =
+    this.copy(size = size + amount)
+  def resizeBy(width: Int, height: Int): Graphic[M] =
+    resizeBy(Size(width, height))
+
   def withCrop(newCrop: Rectangle): Graphic[M] =
-    this.copy(crop = newCrop)
+    this.copy(crop = Option(newCrop))
   def withCrop(x: Int, y: Int, width: Int, height: Int): Graphic[M] =
     withCrop(Rectangle(x, y, width, height))
 
@@ -111,6 +121,7 @@ object Graphic:
 
   def apply[M <: Material](x: Int, y: Int, width: Int, height: Int, material: M): Graphic[M] =
     Graphic(
+      size = Size(width, height),
       eventHandlerEnabled = false,
       eventHandler = Function.const(None),
       position = Point(x, y),
@@ -118,25 +129,13 @@ object Graphic:
       scale = Vector2.one,
       ref = Point.zero,
       flip = Flip.default,
-      crop = Rectangle(0, 0, width, height),
-      material = material
-    )
-
-  def apply[M <: Material](bounds: Rectangle, material: M): Graphic[M] =
-    Graphic(
-      eventHandlerEnabled = false,
-      eventHandler = Function.const(None),
-      position = bounds.position,
-      rotation = Radians.zero,
-      scale = Vector2.one,
-      ref = Point.zero,
-      flip = Flip.default,
-      crop = bounds,
+      crop = None,
       material = material
     )
 
   def apply[M <: Material](width: Int, height: Int, material: M): Graphic[M] =
     Graphic(
+      size = Size(width, height),
       eventHandlerEnabled = false,
       eventHandler = Function.const(None),
       position = Point.zero,
@@ -144,12 +143,13 @@ object Graphic:
       scale = Vector2.one,
       ref = Point.zero,
       flip = Flip.default,
-      crop = Rectangle(0, 0, width, height),
+      crop = None,
       material = material
     )
 
   def apply[M <: Material](size: Size, material: M): Graphic[M] =
     Graphic(
+      size = size,
       eventHandlerEnabled = false,
       eventHandler = Function.const(None),
       position = Point.zero,
@@ -157,6 +157,6 @@ object Graphic:
       scale = Vector2.one,
       ref = Point.zero,
       flip = Flip.default,
-      crop = Rectangle(Point.zero, size),
+      crop = None,
       material = material
     )

--- a/indigo-shaders/src/indigo/shaders/library/Blit.scala
+++ b/indigo-shaders/src/indigo/shaders/library/Blit.scala
@@ -24,7 +24,7 @@ object Blit:
       import TileAndStretch.*
 
       // Delegates
-      val _tileAndStretchChannel: (Int, vec4, sampler2D.type, vec2, vec2, vec2, vec2, vec2, vec4) => vec4 =
+      val _tileAndStretchChannel: (Int, sampler2D.type, vec2, vec2, vec2, vec2, vec2, vec4) => vec4 =
         tileAndStretchChannel
 
       ubo[IndigoBitmapData]
@@ -32,7 +32,6 @@ object Blit:
       def fragment(color: vec4): vec4 =
         env.CHANNEL_0 = _tileAndStretchChannel(
           env.FILLTYPE.toInt,
-          env.CHANNEL_0,
           env.SRC_CHANNEL,
           env.CHANNEL_0_POSITION,
           env.CHANNEL_0_SIZE,
@@ -43,7 +42,6 @@ object Blit:
         )
         env.CHANNEL_1 = _tileAndStretchChannel(
           env.FILLTYPE.toInt,
-          env.CHANNEL_1,
           env.SRC_CHANNEL,
           env.CHANNEL_1_POSITION,
           env.CHANNEL_0_SIZE,
@@ -54,7 +52,6 @@ object Blit:
         )
         env.CHANNEL_2 = _tileAndStretchChannel(
           env.FILLTYPE.toInt,
-          env.CHANNEL_2,
           env.SRC_CHANNEL,
           env.CHANNEL_2_POSITION,
           env.CHANNEL_0_SIZE,
@@ -65,7 +62,6 @@ object Blit:
         )
         env.CHANNEL_3 = _tileAndStretchChannel(
           env.FILLTYPE.toInt,
-          env.CHANNEL_3,
           env.SRC_CHANNEL,
           env.CHANNEL_3_POSITION,
           env.CHANNEL_0_SIZE,

--- a/indigo-shaders/src/indigo/shaders/library/ImageEffects.scala
+++ b/indigo-shaders/src/indigo/shaders/library/ImageEffects.scala
@@ -50,7 +50,7 @@ object ImageEffects:
         val _tileAndStretchChannel: (Int, sampler2D.type, vec2, vec2, vec2, vec2, vec2, vec4) => vec4 =
           tileAndStretchChannel
 
-        // 0 = normal 1 = stretch 2 = tile
+        // 0 = normal, 1 = stretch, 2 = tile, 3 = nine-slice
         val fillType: Int =
           round(env.ALPHA_SATURATION_OVERLAYTYPE_FILLTYPE.w).toInt
 

--- a/indigo-shaders/src/indigo/shaders/library/ImageEffects.scala
+++ b/indigo-shaders/src/indigo/shaders/library/ImageEffects.scala
@@ -47,7 +47,7 @@ object ImageEffects:
           calculateRadialGradientOverlay
         val _calculateSaturation: (vec4, Float) => vec4 =
           calculateSaturation
-        val _tileAndStretchChannel: (Int, vec4, sampler2D.type, vec2, vec2, vec2, vec2, vec2, vec4) => vec4 =
+        val _tileAndStretchChannel: (Int, sampler2D.type, vec2, vec2, vec2, vec2, vec2, vec4) => vec4 =
           tileAndStretchChannel
 
         // 0 = normal 1 = stretch 2 = tile
@@ -56,7 +56,6 @@ object ImageEffects:
 
         env.CHANNEL_0 = _tileAndStretchChannel(
           fillType,
-          env.CHANNEL_0,
           env.SRC_CHANNEL,
           env.CHANNEL_0_POSITION,
           env.CHANNEL_0_SIZE,
@@ -67,7 +66,6 @@ object ImageEffects:
         )
         env.CHANNEL_1 = _tileAndStretchChannel(
           fillType,
-          env.CHANNEL_1,
           env.SRC_CHANNEL,
           env.CHANNEL_1_POSITION,
           env.CHANNEL_0_SIZE,
@@ -78,7 +76,6 @@ object ImageEffects:
         )
         env.CHANNEL_2 = _tileAndStretchChannel(
           fillType,
-          env.CHANNEL_2,
           env.SRC_CHANNEL,
           env.CHANNEL_2_POSITION,
           env.CHANNEL_0_SIZE,
@@ -89,7 +86,6 @@ object ImageEffects:
         )
         env.CHANNEL_3 = _tileAndStretchChannel(
           fillType,
-          env.CHANNEL_3,
           env.SRC_CHANNEL,
           env.CHANNEL_3_POSITION,
           env.CHANNEL_0_SIZE,

--- a/indigo-shaders/src/indigo/shaders/library/TileAndStretch.scala
+++ b/indigo-shaders/src/indigo/shaders/library/TileAndStretch.scala
@@ -4,10 +4,10 @@ import ultraviolet.syntax.*
 
 object TileAndStretch:
 
-  inline def tileAndStretchChannel: (Int, vec4, sampler2D.type, vec2, vec2, vec2, vec2, vec2, vec4) => vec4 =
+  @SuppressWarnings(Array("scalafix:DisableSyntax.var"))
+  inline def tileAndStretchChannel: (Int, sampler2D.type, vec2, vec2, vec2, vec2, vec2, vec4) => vec4 =
     (
         fillType: Int,
-        fallback: vec4,
         srcChannel: sampler2D.type,
         channelPos: vec2,
         channelSize: vec2,
@@ -40,7 +40,17 @@ object TileAndStretch:
           )
 
         case _ =>
-          fallback
+          val clampedUV = clamp(uv * (entitySize / textureSize), 0.0f, 1.0f)
+
+          var col = vec4(0.0f)
+
+          if clampedUV.x < 1.0f && clampedUV.y < 1.0f then
+            col = texture2D(
+              srcChannel,
+              stretchedUVs(clampedUV, channelPos, channelSize)
+            )
+
+          col
 
   inline def stretchedUVs(uv: vec2, channelPos: vec2, channelSize: vec2): vec2 =
     channelPos + uv * channelSize

--- a/indigo-shaders/src/indigo/shaders/library/TileAndStretch.scala
+++ b/indigo-shaders/src/indigo/shaders/library/TileAndStretch.scala
@@ -40,14 +40,13 @@ object TileAndStretch:
           )
 
         case _ =>
-          val clampedUV = clamp(uv * (entitySize / textureSize), 0.0f, 1.0f)
+          val croppedUV = uv * (entitySize / textureSize)
+          var col       = vec4(0.0f)
 
-          var col = vec4(0.0f)
-
-          if clampedUV.x < 1.0f && clampedUV.y < 1.0f then
+          if croppedUV.x <= 1.0f && croppedUV.y <= 1.0f then
             col = texture2D(
               srcChannel,
-              stretchedUVs(clampedUV, channelPos, channelSize)
+              stretchedUVs(croppedUV, channelPos, channelSize)
             )
 
           col

--- a/ultraviolet-sandbox/src/com/example/sandbox/SandboxAssets.scala
+++ b/ultraviolet-sandbox/src/com/example/sandbox/SandboxAssets.scala
@@ -31,13 +31,13 @@ object SandboxAssets {
     Graphic(32, 32, Material.Bitmap(dots))
 
   val redDot: Graphic[Material.Bitmap] =
-    Graphic(Rectangle(0, 0, 16, 16), Material.Bitmap(dots)).withRef(8, 8)
+    Graphic(Size(16), Material.Bitmap(dots)).withRef(8, 8).withCrop(Rectangle(0, 0, 16, 16))
   val greenDot: Graphic[Material.Bitmap] =
-    Graphic(Rectangle(16, 0, 16, 16), Material.Bitmap(dots)).withRef(8, 8)
+    Graphic(Size(16), Material.Bitmap(dots)).withRef(8, 8).withCrop(Rectangle(16, 0, 16, 16))
   val blueDot: Graphic[Material.Bitmap] =
-    Graphic(Rectangle(0, 16, 16, 16), Material.Bitmap(dots)).withRef(8, 8)
+    Graphic(Size(16), Material.Bitmap(dots)).withRef(8, 8).withCrop(Rectangle(0, 16, 16, 16))
   val yellowDot: Graphic[Material.Bitmap] =
-    Graphic(Rectangle(16, 16, 16, 16), Material.Bitmap(dots)).withRef(8, 8)
+    Graphic(Size(16), Material.Bitmap(dots)).withRef(8, 8).withCrop(Rectangle(16, 16, 16, 16))
 
   val junctionBoxAlbedo: AssetName    = AssetName("junctionbox_albedo")
   val junctionBoxEmission: AssetName  = AssetName("junctionbox_emission")


### PR DESCRIPTION
Related to: https://github.com/PurpleKingdomGames/indigoengine/issues/195

It appeared to be an issue only with the nineslice fill type, but actually affected all fill types. The solution sanitises the whole process (the way graphics handled crops was always a little suspect). There are some breaking API changes but this are not a concern as usual.