### PR TITLE
FIXED #196: Add option to disable most shader validation

### DIFF
--- a/ultraviolet/src/ultraviolet/datatypes/Shader.scala
+++ b/ultraviolet/src/ultraviolet/datatypes/Shader.scala
@@ -43,23 +43,43 @@ object Shader:
       toGLSL(ProgramVersion.GLSL_410, headers)
 
     inline def toGLSL(inline version: ProgramVersion): ShaderResult =
-      ShaderMacros.toGLSL(ctx, Nil, version)
+      ShaderMacros.toGLSL(ctx, Nil, version, true)
 
     inline def toGLSL(inline version: ProgramVersion, inline headers: List[ShaderHeader]): ShaderResult =
-      ShaderMacros.toGLSL(ctx, headers, version)
+      ShaderMacros.toGLSL(ctx, headers, version, true)
+
+    inline def toGLSL(
+        inline version: ProgramVersion,
+        inline headers: List[ShaderHeader],
+        inline useValidation: Boolean
+    ): ShaderResult =
+      ShaderMacros.toGLSL(ctx, headers, version, useValidation)
 
     /** Returns the `ProceduralShader` AST before any version-specific transformers are applied. Useful for debugging -
       * pair with `ShaderASTPrinter.print` for a readable tree view.
       */
     inline def toAST: ProceduralShader =
-      ShaderMacros.toAST(ctx)
+      ShaderMacros.toAST(ctx, true)
+
+    /** Returns the `ProceduralShader` AST before any version-specific transformers are applied. Useful for debugging -
+      * pair with `ShaderASTPrinter.print` for a readable tree view.
+      */
+    inline def toASTNoValidation: ProceduralShader =
+      ShaderMacros.toAST(ctx, false)
 
     /** Returns the `ProceduralShader` AST after the given version's transformers have been applied. Useful for
       * debugging - pair with `ShaderASTPrinter.print` for a readable tree view, and compare against `toAST` to see what
       * the transformers changed.
       */
     inline def toASTTransformed(inline version: ProgramVersion): ProceduralShader =
-      ShaderMacros.toASTTransformed(ctx, version)
+      ShaderMacros.toASTTransformed(ctx, version, true)
+
+    /** Returns the `ProceduralShader` AST after the given version's transformers have been applied. Useful for
+      * debugging - pair with `ShaderASTPrinter.print` for a readable tree view, and compare against `toAST` to see what
+      * the transformers changed.
+      */
+    inline def toASTTransformedNoValidation(inline version: ProgramVersion): ProceduralShader =
+      ShaderMacros.toASTTransformed(ctx, version, false)
 
     inline def run(in: In): Out = ctx(in)
 

--- a/ultraviolet/src/ultraviolet/macros/ShaderMacros.scala
+++ b/ultraviolet/src/ultraviolet/macros/ShaderMacros.scala
@@ -132,8 +132,17 @@ object ShaderMacros:
         "sampler2D"
       )
 
+    // Defaults to validation enabled. Only disables validation explicitly.
     useValidation.value match
-      case Some(true) =>
+      case Some(false) =>
+        ProceduralShader(
+          defs,
+          createAST.uboRegister.toList,
+          annotations,
+          main
+        )
+
+      case _ =>
         ProceduralShader(
           ShaderProgramValidation.validateFunctionList(defs, ShaderDSLOps.allKeywords ++ additionalKeyword),
           createAST.uboRegister.toList,
@@ -142,14 +151,6 @@ object ShaderMacros:
             0,
             ShaderDSLOps.allKeywords ++ additionalKeyword ++ defRefs ++ annotationRefs
           )(main)
-        )
-
-      case _ =>
-        ProceduralShader(
-          defs,
-          createAST.uboRegister.toList,
-          annotations,
-          main
         )
   }
 

--- a/ultraviolet/src/ultraviolet/macros/ShaderMacros.scala
+++ b/ultraviolet/src/ultraviolet/macros/ShaderMacros.scala
@@ -18,16 +18,18 @@ object ShaderMacros:
   inline def toGLSL[In, Out](
       inline shader: Shader[In, Out],
       inline headers: List[ShaderHeader],
-      inline version: ProgramVersion
+      inline version: ProgramVersion,
+      inline useValidation: Boolean
   ): ShaderResult =
-    ${ toGLSLImpl('{ shader }, '{ headers }, '{ version }) }
+    ${ toGLSLImpl('{ shader }, '{ headers }, '{ version }, '{ useValidation }) }
 
   @nowarn("msg=unused")
   @SuppressWarnings(Array("scalafix:DisableSyntax.throw"))
   private[macros] def toGLSLImpl[In, Out: Type](
       shader: Expr[Shader[In, Out]],
       headers: Expr[List[ShaderHeader]],
-      version: Expr[ProgramVersion]
+      version: Expr[ProgramVersion],
+      useValidation: Expr[Boolean]
   )(using q: Quotes): Expr[ShaderResult] =
     import quotes.reflect.*
 
@@ -46,7 +48,7 @@ object ShaderMacros:
           |headers expr: ${headers.asTerm.show(using Printer.TreeStructure)}""".stripMargin
         )
       }
-      val p = buildProceduralShader(shader)
+      val p = buildProceduralShader(shader, useValidation)
 
       p.validate(v.requirements) match
         case ShaderValid.Valid =>
@@ -63,23 +65,25 @@ object ShaderMacros:
         report.errorAndAbort(e.message)
     }
 
-  inline def toAST[In, Out](inline expr: Shader[In, Out]): ProceduralShader =
-    ${ toASTImpl('{ expr }) }
+  inline def toAST[In, Out](inline expr: Shader[In, Out], inline useValidation: Boolean): ProceduralShader =
+    ${ toASTImpl('{ expr }, '{ useValidation }) }
 
-  private[macros] def toASTImpl[In, Out: Type](expr: Expr[Shader[In, Out]])(using
+  private[macros] def toASTImpl[In, Out: Type](expr: Expr[Shader[In, Out]], useValidation: Expr[Boolean])(using
       q: Quotes
   ): Expr[ProceduralShader] =
-    Expr(buildProceduralShader(expr))
+    Expr(buildProceduralShader(expr, useValidation))
 
   inline def toASTTransformed[In, Out](
       inline expr: Shader[In, Out],
-      inline version: ProgramVersion
+      inline version: ProgramVersion,
+      inline useValidation: Boolean
   ): ProceduralShader =
-    ${ toASTTransformedImpl('{ expr }, '{ version }) }
+    ${ toASTTransformedImpl('{ expr }, '{ version }, '{ useValidation }) }
 
   private[macros] def toASTTransformedImpl[In, Out: Type](
       expr: Expr[Shader[In, Out]],
-      version: Expr[ProgramVersion]
+      version: Expr[ProgramVersion],
+      useValidation: Expr[Boolean]
   )(using q: Quotes): Expr[ProceduralShader] =
     import quotes.reflect.*
 
@@ -91,14 +95,13 @@ object ShaderMacros:
       )
     }
 
-    val p = buildProceduralShader(expr)
+    val p = buildProceduralShader(expr, useValidation)
     Expr(p.applyTransformers(v.transformers))
 
-  private[macros] def buildProceduralShader[In, Out: Type](expr: Expr[Shader[In, Out]])(using
-      q: Quotes
+  private[macros] def buildProceduralShader[In, Out: Type](expr: Expr[Shader[In, Out]], useValidation: Expr[Boolean])(
+      using q: Quotes
   ): ProceduralShader = {
     import q.reflect.*
-    import ShaderProgramValidation.*
 
     val createAST = new CreateShaderAST[q.type](using q)
 
@@ -129,12 +132,25 @@ object ShaderMacros:
         "sampler2D"
       )
 
-    ProceduralShader(
-      validateFunctionList(defs, ShaderDSLOps.allKeywords ++ additionalKeyword),
-      createAST.uboRegister.toList,
-      annotations,
-      validate(0, ShaderDSLOps.allKeywords ++ additionalKeyword ++ defRefs ++ annotationRefs)(main)
-    )
+    useValidation.value match
+      case Some(true) =>
+        ProceduralShader(
+          ShaderProgramValidation.validateFunctionList(defs, ShaderDSLOps.allKeywords ++ additionalKeyword),
+          createAST.uboRegister.toList,
+          annotations,
+          ShaderProgramValidation.validate(
+            0,
+            ShaderDSLOps.allKeywords ++ additionalKeyword ++ defRefs ++ annotationRefs
+          )(main)
+        )
+
+      case _ =>
+        ProceduralShader(
+          defs,
+          createAST.uboRegister.toList,
+          annotations,
+          main
+        )
   }
 
   inline def fromFile(inline expr: String): RawGLSL = ${ fromFileImpl('{ expr }) }

--- a/ultraviolet/src/ultraviolet/utils/ShaderASTPrinter.scala
+++ b/ultraviolet/src/ultraviolet/utils/ShaderASTPrinter.scala
@@ -16,11 +16,23 @@ import ultraviolet.macros.ShaderMacros
 object ShaderASTPrinter:
 
   inline def printAST[In, Out](inline shader: Shader[In, Out]): String =
-    val proc = ShaderMacros.toAST(shader)
+    val proc = ShaderMacros.toAST(shader, true)
+    print(proc)
+
+  inline def printAST[In, Out](inline shader: Shader[In, Out], inline useValidation: Boolean): String =
+    val proc = ShaderMacros.toAST(shader, useValidation)
     print(proc)
 
   inline def printASTTransformed[In, Out](inline shader: Shader[In, Out], inline version: ProgramVersion): String =
-    val proc = ShaderMacros.toASTTransformed(shader, version)
+    val proc = ShaderMacros.toASTTransformed(shader, version, true)
+    print(proc)
+
+  inline def printASTTransformed[In, Out](
+      inline shader: Shader[In, Out],
+      inline version: ProgramVersion,
+      inline useValidation: Boolean
+  ): String =
+    val proc = ShaderMacros.toASTTransformed(shader, version, useValidation)
     print(proc)
 
   def print(p: ProceduralShader): String =

--- a/ultraviolet/test/src-jvm/ultraviolet/utils/ShaderASTPrinterTests.scala
+++ b/ultraviolet/test/src-jvm/ultraviolet/utils/ShaderASTPrinterTests.scala
@@ -168,7 +168,7 @@ class ShaderASTPrinterTests extends munit.FunSuite {
     assert(output.contains("Val 'h'"))
   }
 
-  test("Can print and invalid AST (Example used: Nested named functions)") {
+  test("Can print an invalid AST (Example used: Nested named functions)") {
     inline def fragment =
       Shader {
         def foo(i: Int): Int =

--- a/ultraviolet/test/src-jvm/ultraviolet/utils/ShaderASTPrinterTests.scala
+++ b/ultraviolet/test/src-jvm/ultraviolet/utils/ShaderASTPrinterTests.scala
@@ -137,7 +137,7 @@ class ShaderASTPrinterTests extends munit.FunSuite {
         val h: Float = 1.0f
       }
 
-    val proc   = ShaderMacros.toAST(fragment)
+    val proc   = ShaderMacros.toAST(fragment, true)
     val output = ShaderASTPrinter.print(proc)
 
     assert(output.startsWith("ProceduralShader"))
@@ -166,6 +166,25 @@ class ShaderASTPrinterTests extends munit.FunSuite {
 
     assert(output.startsWith("ProceduralShader"))
     assert(output.contains("Val 'h'"))
+  }
+
+  test("Can print and invalid AST (Example used: Nested named functions)") {
+    inline def fragment =
+      Shader {
+        def foo(i: Int): Int =
+          def bar(): Int = 10
+          bar()
+      }
+
+    val output =
+      ShaderASTPrinter.printAST(
+        fragment,
+        useValidation = false // Does not compile if set to true.
+      )
+
+    assert(clue(output).startsWith("ProceduralShader"))
+    assert(clue(output).contains("Function 'foo'"))
+    assert(clue(output).contains("Function 'bar'"))
   }
 
 }

--- a/ultraviolet/test/src/ultraviolet/datatypes/ProceduralShaderTests.scala
+++ b/ultraviolet/test/src/ultraviolet/datatypes/ProceduralShaderTests.scala
@@ -57,7 +57,7 @@ class ProceduralShaderTests extends munit.FunSuite {
     // DebugAST.toAST(fragment)
 
     val actual =
-      ShaderMacros.toAST(fragment).find {
+      ShaderMacros.toAST(fragment, true).find {
         case r @ ShaderAST.DataTypes.vec2(_) => true
         case _                               => false
       }
@@ -92,7 +92,7 @@ class ProceduralShaderTests extends munit.FunSuite {
       }
 
     val actual =
-      ShaderMacros.toAST(fragment).findAll {
+      ShaderMacros.toAST(fragment, true).findAll {
         case r @ ShaderAST.DataTypes.vec2(_) => true
         case _                               => false
       }

--- a/ultraviolet/test/src/ultraviolet/datatypes/ShaderASTTests.scala
+++ b/ultraviolet/test/src/ultraviolet/datatypes/ShaderASTTests.scala
@@ -19,7 +19,7 @@ class ShaderASTTests extends munit.FunSuite {
 
     val acc = new ListBuffer[String]()
 
-    val ast = ShaderMacros.toAST(fragment).main
+    val ast = ShaderMacros.toAST(fragment, true).main
 
     ast.traverse { case v @ ShaderAST.Val(id, _, _) =>
       acc += id


### PR DESCRIPTION
Related to https://github.com/PurpleKingdomGames/indigoengine/issues/196

This disables the general program validation, e.g. there is a test example where I've used nested functions, which is normally not allow, but it happily compiles. There is _some_ validation we cannot disable, for instance use of GLSL reserved words - I now think incorrectly - are caught mid conversion rather than as a proper validation step. I might raise an issue about that...
