### PR TITLE
WindowEvent.Opened and WindowEvent.Closed now pass through to underlying windows

### DIFF
--- a/indigo-extras/src/indigoextras/ui/window/WindowManager.scala
+++ b/indigo-extras/src/indigoextras/ui/window/WindowManager.scala
@@ -290,12 +290,6 @@ object WindowManager:
     case WindowEvent.Transform(id, bounds, space) =>
       model.transformTo(id, bounds, space, context.frame.viewport, context.magnification).refresh(context, id)
 
-    case WindowEvent.Opened(_) =>
-      Outcome(model)
-
-    case WindowEvent.Closed(_) =>
-      Outcome(model)
-
     case WindowEvent.Resized(_) =>
       Outcome(model)
 
@@ -315,6 +309,10 @@ object WindowManager:
 
         case Some(window) =>
           model.close(window.id)
+
+    // Pass through opened and closed events so that windows can deal with them
+    case e: (WindowEvent.Opened | WindowEvent.Closed) =>
+      updateWindows(context, model, modalWindowOpen(model))(e)
 
   private[window] def updateViewModel[ReferenceData](
       context: UIContext[ReferenceData],


### PR DESCRIPTION
Previously the events would be dropped, but that meant that windows could never be notified if they had been opened or closed

Fixes #214
