### PR TITLE
Re-engineers how events are distributed in the UI

### DIFF
--- a/indigo-core/src/indigo/core/events/InputEvent.scala
+++ b/indigo-core/src/indigo/core/events/InputEvent.scala
@@ -879,6 +879,27 @@ object PointerEvent:
       pointerType: PointerType
   ) extends PointerEvent
   object Enter:
+    def apply(pointerId: PointerId, position: Point, movementPosition: Point, pointerType: PointerType): Enter =
+      Enter(
+        pointerId = pointerId,
+        position = position,
+        buttons = Batch.empty,
+        isAltKeyDown = false,
+        isCtrlKeyDown = false,
+        isMetaKeyDown = false,
+        isShiftKeyDown = false,
+        movementPosition = movementPosition,
+        width = 0,
+        height = 0,
+        pressure = 0,
+        tangentialPressure = 0,
+        tiltX = Radians.zero,
+        tiltY = Radians.zero,
+        twist = Radians.zero,
+        pointerType = pointerType,
+        isPrimary = true
+      )
+
     def unapply(e: Enter): Option[Point] =
       Option(e.position)
 
@@ -891,6 +912,27 @@ object PointerEvent:
       pointerType: PointerType
   ) extends PointerEvent
   object Leave:
+    def apply(pointerId: PointerId, position: Point, movementPosition: Point, pointerType: PointerType): Leave =
+      Leave(
+        pointerId = pointerId,
+        position = position,
+        buttons = Batch.empty,
+        isAltKeyDown = false,
+        isCtrlKeyDown = false,
+        isMetaKeyDown = false,
+        isShiftKeyDown = false,
+        movementPosition = movementPosition,
+        width = 0,
+        height = 0,
+        pressure = 0,
+        tangentialPressure = 0,
+        tiltX = Radians.zero,
+        tiltY = Radians.zero,
+        twist = Radians.zero,
+        pointerType = pointerType,
+        isPrimary = true
+      )
+
     def unapply(e: Leave): Option[Point] =
       Option(e.position)
 

--- a/indigo-core/src/indigo/core/events/InputEvent.scala
+++ b/indigo-core/src/indigo/core/events/InputEvent.scala
@@ -879,27 +879,6 @@ object PointerEvent:
       pointerType: PointerType
   ) extends PointerEvent
   object Enter:
-    def apply(pointerId: PointerId, position: Point, movementPosition: Point, pointerType: PointerType): Enter =
-      Enter(
-        pointerId = pointerId,
-        position = position,
-        buttons = Batch.empty,
-        isAltKeyDown = false,
-        isCtrlKeyDown = false,
-        isMetaKeyDown = false,
-        isShiftKeyDown = false,
-        movementPosition = movementPosition,
-        width = 0,
-        height = 0,
-        pressure = 0,
-        tangentialPressure = 0,
-        tiltX = Radians.zero,
-        tiltY = Radians.zero,
-        twist = Radians.zero,
-        pointerType = pointerType,
-        isPrimary = true
-      )
-
     def unapply(e: Enter): Option[Point] =
       Option(e.position)
 
@@ -912,27 +891,6 @@ object PointerEvent:
       pointerType: PointerType
   ) extends PointerEvent
   object Leave:
-    def apply(pointerId: PointerId, position: Point, movementPosition: Point, pointerType: PointerType): Leave =
-      Leave(
-        pointerId = pointerId,
-        position = position,
-        buttons = Batch.empty,
-        isAltKeyDown = false,
-        isCtrlKeyDown = false,
-        isMetaKeyDown = false,
-        isShiftKeyDown = false,
-        movementPosition = movementPosition,
-        width = 0,
-        height = 0,
-        pressure = 0,
-        tangentialPressure = 0,
-        tiltX = Radians.zero,
-        tiltY = Radians.zero,
-        twist = Radians.zero,
-        pointerType = pointerType,
-        isPrimary = true
-      )
-
     def unapply(e: Leave): Option[Point] =
       Option(e.position)
 

--- a/indigo-core/src/indigo/core/input/MouseState.scala
+++ b/indigo-core/src/indigo/core/input/MouseState.scala
@@ -139,16 +139,19 @@ final case class MouseState(
         val newInstance = event match {
           case e: MouseEvent.Move  => instance.copy(maybePosition = Some(e.position))
           case e: MouseEvent.Enter => instance.copy(maybePosition = Some(e.position))
-          case e: MouseEvent.Click => instance.copy(clicks = instance.clicks :+ (e.button, e.position))
+          case e: MouseEvent.Click =>
+            instance.copy(clicks = instance.clicks :+ (e.button, e.position), maybePosition = Some(e.position))
           case e: MouseEvent.Down =>
             instance.copy(
               downButtons = instance.downButtons :+ (e.button, e.position),
-              buttons = instance.buttons :+ e.button
+              buttons = instance.buttons :+ e.button,
+              maybePosition = Some(e.position)
             )
           case e: MouseEvent.Up =>
             instance.copy(
               upButtons = instance.upButtons :+ (e.button, e.position),
-              buttons = instance.buttons.filterNot(_ == e.button)
+              buttons = instance.buttons.filterNot(_ == e.button),
+              maybePosition = Some(e.position)
             )
           // We should never reach here
           case _: MouseEvent.Leave => instance

--- a/indigo-core/src/indigo/core/input/PointerState.scala
+++ b/indigo-core/src/indigo/core/input/PointerState.scala
@@ -66,8 +66,18 @@ final case class PointerState(instances: Batch[Pointer]) extends ButtonInputStat
           case e: PointerEvent.Enter => instance.copy(maybePosition = Some(e.position), lastUpdateTime = time)
           case e: PointerEvent.Click =>
             e.button match {
-              case Some(value) => instance.copy(clicks = instance.clicks :+ (value, e.position), lastUpdateTime = time)
-              case None => instance.copy(isTapped = true, maybePosition = Some(e.position), lastUpdateTime = time)
+              case Some(value) =>
+                instance.copy(
+                  clicks = instance.clicks :+ (value, e.position),
+                  lastUpdateTime = time,
+                  maybePosition = Some(e.position)
+                )
+              case None =>
+                instance.copy(
+                  isTapped = true,
+                  maybePosition = Some(e.position),
+                  lastUpdateTime = time
+                )
             }
           case e: PointerEvent.Down =>
             e.button match {
@@ -77,9 +87,10 @@ final case class PointerState(instances: Batch[Pointer]) extends ButtonInputStat
                   buttons = instance.buttons :+ value,
                   isDown =
                     (e.pointerType == PointerType.Mouse && value == MouseButton.LeftMouseButton) || instance.isDown,
-                  lastUpdateTime = time
+                  lastUpdateTime = time,
+                  maybePosition = Some(e.position)
                 )
-              case None => instance.copy(isDown = true, lastUpdateTime = time)
+              case None => instance.copy(isDown = true, lastUpdateTime = time, maybePosition = Some(e.position))
             }
           case e: PointerEvent.Up =>
             e.button match {
@@ -90,9 +101,10 @@ final case class PointerState(instances: Batch[Pointer]) extends ButtonInputStat
                   isDown =
                     if e.pointerType == PointerType.Mouse && value == MouseButton.LeftMouseButton then false
                     else instance.isDown,
-                  lastUpdateTime = time
+                  lastUpdateTime = time,
+                  maybePosition = Some(e.position)
                 )
-              case None => instance.copy(isDown = false, lastUpdateTime = time)
+              case None => instance.copy(isDown = false, lastUpdateTime = time, maybePosition = Some(e.position))
             }
           // We should never reach here
           case _: PointerEvent.Leave => instance

--- a/indigo-extras/src/indigoextras/ui/component/Component.scala
+++ b/indigo-extras/src/indigoextras/ui/component/Component.scala
@@ -30,6 +30,10 @@ trait Component[A, ReferenceData]:
     val _ = _event
     hitTest(context, model)
 
+  /** True when this component owns pointer input until the current pointer interaction ends. */
+  def hasPointerCapture(context: UIContext[ReferenceData], model: A): Boolean =
+    false
+
   /** Produce a renderable output for this component, based on the component's model.
     */
   def present(

--- a/indigo-extras/src/indigoextras/ui/component/Component.scala
+++ b/indigo-extras/src/indigoextras/ui/component/Component.scala
@@ -20,6 +20,16 @@ trait Component[A, ReferenceData]:
       model: A
   ): GlobalEvent => Outcome[A]
 
+  /** True if this component, or one of its children, is a valid target for pointer routing at the current pointer
+    * position.
+    */
+  def hitTest(context: UIContext[ReferenceData], model: A): Boolean =
+    false
+
+  def hitTest(context: UIContext[ReferenceData], model: A, _event: GlobalEvent): Boolean =
+    val _ = _event
+    hitTest(context, model)
+
   /** Produce a renderable output for this component, based on the component's model.
     */
   def present(
@@ -44,6 +54,12 @@ object Component:
           model: Unit
       ): GlobalEvent => Outcome[Unit] =
         _ => Outcome(model)
+
+      override def hitTest(context: UIContext[ReferenceData], model: Unit): Boolean =
+        false
+
+      override def hitTest(context: UIContext[ReferenceData], model: Unit, event: GlobalEvent): Boolean =
+        false
 
       def present(
           context: UIContext[ReferenceData],

--- a/indigo-extras/src/indigoextras/ui/component/Component.scala
+++ b/indigo-extras/src/indigoextras/ui/component/Component.scala
@@ -2,6 +2,7 @@ package indigoextras.ui.component
 
 import indigo.*
 import indigoextras.ui.datatypes.Bounds
+import indigoextras.ui.datatypes.Coords
 import indigoextras.ui.datatypes.UIContext
 
 /** A typeclass that confirms that some type `A` can be used as a `Component` provides the necessary operations for that
@@ -13,7 +14,13 @@ trait Component[A, ReferenceData]:
     */
   def bounds(context: UIContext[ReferenceData], model: A): Bounds
 
-  /** Update this componenet's model.
+  def coordsInBounds(pnt: Coords, context: UIContext[ReferenceData], model: A): Boolean =
+    context.pointerIsWithinActiveInputBounds &&
+      bounds(context, model)
+        .moveBy(context.parent.coords + context.parent.additionalOffset)
+        .contains(pnt)
+
+  /** Update this component's model.
     */
   def updateModel(
       context: UIContext[ReferenceData],
@@ -23,10 +30,14 @@ trait Component[A, ReferenceData]:
   /** Indicates if this component, or one of its children, is a valid target for pointer routing at the current pointer
     * position.
     */
-  def hitTest(context: UIContext[ReferenceData], model: A, event: GlobalEvent): Boolean
+  def hitTest(context: UIContext[ReferenceData], model: A, event: GlobalEvent): Boolean =
+    event match
+      // By default wheel events don't execute a hit test - this may be overriden by things like scroll panes
+      case _: WheelEvent => false
+      case _             => coordsInBounds(context.pointerCoords, context, model)
 
   /** Indicates if this component owns pointer input until the current pointer interaction ends. */
-  def hasPointerCapture(context: UIContext[ReferenceData], model: A): Boolean
+  def hasPointerCapture(context: UIContext[ReferenceData], model: A): Boolean = false
 
   /** Produce a renderable output for this component, based on the component's model.
     */
@@ -52,12 +63,6 @@ object Component:
           model: Unit
       ): GlobalEvent => Outcome[Unit] =
         _ => Outcome(model)
-
-      def hitTest(context: UIContext[ReferenceData], model: Unit, event: GlobalEvent): Boolean =
-        false
-
-      def hasPointerCapture(context: UIContext[ReferenceData], model: Unit): Boolean =
-        false
 
       def present(
           context: UIContext[ReferenceData],

--- a/indigo-extras/src/indigoextras/ui/component/Component.scala
+++ b/indigo-extras/src/indigoextras/ui/component/Component.scala
@@ -20,19 +20,13 @@ trait Component[A, ReferenceData]:
       model: A
   ): GlobalEvent => Outcome[A]
 
-  /** True if this component, or one of its children, is a valid target for pointer routing at the current pointer
+  /** Indicates if this component, or one of its children, is a valid target for pointer routing at the current pointer
     * position.
     */
-  def hitTest(context: UIContext[ReferenceData], model: A): Boolean =
-    false
+  def hitTest(context: UIContext[ReferenceData], model: A, event: GlobalEvent): Boolean
 
-  def hitTest(context: UIContext[ReferenceData], model: A, _event: GlobalEvent): Boolean =
-    val _ = _event
-    hitTest(context, model)
-
-  /** True when this component owns pointer input until the current pointer interaction ends. */
-  def hasPointerCapture(context: UIContext[ReferenceData], model: A): Boolean =
-    false
+  /** Indicates if this component owns pointer input until the current pointer interaction ends. */
+  def hasPointerCapture(context: UIContext[ReferenceData], model: A): Boolean
 
   /** Produce a renderable output for this component, based on the component's model.
     */
@@ -59,10 +53,10 @@ object Component:
       ): GlobalEvent => Outcome[Unit] =
         _ => Outcome(model)
 
-      override def hitTest(context: UIContext[ReferenceData], model: Unit): Boolean =
+      def hitTest(context: UIContext[ReferenceData], model: Unit, event: GlobalEvent): Boolean =
         false
 
-      override def hitTest(context: UIContext[ReferenceData], model: Unit, event: GlobalEvent): Boolean =
+      def hasPointerCapture(context: UIContext[ReferenceData], model: Unit): Boolean =
         false
 
       def present(

--- a/indigo-extras/src/indigoextras/ui/components/Button.scala
+++ b/indigo-extras/src/indigoextras/ui/components/Button.scala
@@ -334,15 +334,12 @@ object Button:
       case _ =>
         Outcome(model)
 
-    override def hitTest(context: UIContext[ReferenceData], model: Button[ReferenceData]): Boolean =
-      coordsInBounds(context.pointerCoords, model.bounds, context)
-
-    override def hitTest(context: UIContext[ReferenceData], model: Button[ReferenceData], event: GlobalEvent): Boolean =
+    def hitTest(context: UIContext[ReferenceData], model: Button[ReferenceData], event: GlobalEvent): Boolean =
       event match
         case _: WheelEvent => false
-        case _             => hitTest(context, model)
+        case _             => coordsInBounds(context.pointerCoords, model.bounds, context)
 
-    override def hasPointerCapture(context: UIContext[ReferenceData], model: Button[ReferenceData]): Boolean =
+    def hasPointerCapture(context: UIContext[ReferenceData], model: Button[ReferenceData]): Boolean =
       model.isDown
 
     def present(
@@ -411,7 +408,7 @@ object Button:
           )
 
     private def coordsInBounds(pnt: Coords, bounds: Bounds, context: UIContext[ReferenceData]): Boolean =
-      context.pointerIsWithinInputClip &&
+      context.pointerIsWithinActiveInputBounds &&
         bounds
           .moveBy(context.parent.coords + context.parent.additionalOffset)
           .contains(pnt)

--- a/indigo-extras/src/indigoextras/ui/components/Button.scala
+++ b/indigo-extras/src/indigoextras/ui/components/Button.scala
@@ -342,6 +342,9 @@ object Button:
         case _: WheelEvent => false
         case _             => hitTest(context, model)
 
+    override def hasPointerCapture(context: UIContext[ReferenceData], model: Button[ReferenceData]): Boolean =
+      model.isDown
+
     def present(
         context: UIContext[ReferenceData],
         model: Button[ReferenceData]

--- a/indigo-extras/src/indigoextras/ui/components/Button.scala
+++ b/indigo-extras/src/indigoextras/ui/components/Button.scala
@@ -229,26 +229,27 @@ object Button:
       case FrameTick =>
         val newBounds =
           model.boundsType match
-            case BoundsType.Fixed(bounds) =>
-              bounds
+            case BoundsType.Fixed(bounds)         => bounds
+            case BoundsType.Calculated(calculate) => calculate(context, ())
+            case _                                => model.bounds
 
-            case BoundsType.Calculated(calculate) =>
-              calculate(context, ())
+        val updated =
+          model.copy(bounds = newBounds)
 
-            case _ =>
-              model.bounds
+        val stillOver =
+          context.isActive && coordsInBounds(context.pointerCoords, context, updated)
 
-        Outcome(
-          model.copy(
-            bounds = newBounds
-          )
-        )
+        if model.isDown && context.isActive then Outcome(updated)
+        else if context.isActive == false || (model.isOver && !stillOver) then
+          Outcome(updated.copy(state = ButtonState.Up, isOver = false))
+            .addGlobalEvents(model.leave(context.reference))
+        else Outcome(updated)
 
       case FocusEvent.LostFocus | FocusEvent.ApplicationLostFocus =>
         Outcome(model.copy(state = ButtonState.Up, isDown = false, isOver = false, dragStart = None))
 
       case _: PointerEvent.Enter
-          if context.isActive && !model.isDown && coordsInBounds(context.pointerCoords, model.bounds, context) =>
+          if context.isActive && !model.isDown && coordsInBounds(context.pointerCoords, context, model) =>
         Outcome(model.copy(state = ButtonState.Over, isOver = true))
           .addGlobalEvents(
             if model.isOver then Batch.empty else model.enter(context.reference)

--- a/indigo-extras/src/indigoextras/ui/components/Button.scala
+++ b/indigo-extras/src/indigoextras/ui/components/Button.scala
@@ -263,25 +263,25 @@ object Button:
 
       case _: PointerEvent.Move
           if context.isActive && !model.isDown && model.isOver &&
-            !coordsInBounds(context.pointerCoords, model.bounds, context) =>
+            !coordsInBounds(context.pointerCoords, context, model) =>
         Outcome(model.copy(state = ButtonState.Up, isOver = false))
           .addGlobalEvents(model.leave(context.reference))
 
       case _: PointerEvent.Move
           if context.isActive && !model.isDown && !model.isOver &&
-            coordsInBounds(context.pointerCoords, model.bounds, context) =>
+            coordsInBounds(context.pointerCoords, context, model) =>
         Outcome(model.copy(state = ButtonState.Over, isOver = true))
           .addGlobalEvents(model.enter(context.reference))
 
-      case _: PointerEvent.Click if context.isActive && coordsInBounds(context.pointerCoords, model.bounds, context) =>
+      case _: PointerEvent.Click if context.isActive && coordsInBounds(context.pointerCoords, context, model) =>
         Outcome(model.copy(state = ButtonState.Over, isDown = false, isOver = true, dragStart = None))
           .addGlobalEvents(model.click(context.reference))
 
-      case _: PointerEvent.Down if context.isActive && coordsInBounds(context.pointerCoords, model.bounds, context) =>
+      case _: PointerEvent.Down if context.isActive && coordsInBounds(context.pointerCoords, context, model) =>
         Outcome(model.copy(state = ButtonState.Down, isDown = true, isOver = true, dragStart = None))
           .addGlobalEvents(model.press(context.reference))
 
-      case _: PointerEvent.Up if context.isActive && coordsInBounds(context.pointerCoords, model.bounds, context) =>
+      case _: PointerEvent.Up if context.isActive && coordsInBounds(context.pointerCoords, context, model) =>
         Outcome(model.copy(state = ButtonState.Over, isDown = false, isOver = true, dragStart = None))
           .addGlobalEvents(model.release(context.reference))
 
@@ -334,12 +334,7 @@ object Button:
       case _ =>
         Outcome(model)
 
-    def hitTest(context: UIContext[ReferenceData], model: Button[ReferenceData], event: GlobalEvent): Boolean =
-      event match
-        case _: WheelEvent => false
-        case _             => coordsInBounds(context.pointerCoords, model.bounds, context)
-
-    def hasPointerCapture(context: UIContext[ReferenceData], model: Button[ReferenceData]): Boolean =
+    override def hasPointerCapture(context: UIContext[ReferenceData], model: Button[ReferenceData]): Boolean =
       model.isDown
 
     def present(
@@ -406,12 +401,6 @@ object Button:
               context.parent.bounds.height - padding.top - padding.bottom
             )
           )
-
-    private def coordsInBounds(pnt: Coords, bounds: Bounds, context: UIContext[ReferenceData]): Boolean =
-      context.pointerIsWithinActiveInputBounds &&
-        bounds
-          .moveBy(context.parent.coords + context.parent.additionalOffset)
-          .contains(pnt)
 
 enum ButtonState derives CanEqual:
   case Up, Over, Down

--- a/indigo-extras/src/indigoextras/ui/components/Button.scala
+++ b/indigo-extras/src/indigoextras/ui/components/Button.scala
@@ -287,12 +287,20 @@ object Button:
 
       case _: PointerEvent.Up =>
         // Released Outside.
-        Outcome(model.copy(state = ButtonState.Up, isDown = false, dragStart = None))
+        Outcome(model.copy(state = ButtonState.Up, isDown = false, isOver = false, dragStart = None))
+          .addGlobalEvents(
+            if model.isOver then model.leave(context.reference)
+            else Batch.empty
+          )
 
       case _: PointerEvent.Move
           if (context.isActive || model.isDragged) && model.isDown && !context.frame.input.pointer.isDown =>
         // Released outside the window at some point.
-        Outcome(model.copy(state = ButtonState.Up, isDown = false, dragStart = None))
+        Outcome(model.copy(state = ButtonState.Up, isDown = false, isOver = false, dragStart = None))
+          .addGlobalEvents(
+            if model.isOver then model.leave(context.reference)
+            else Batch.empty
+          )
 
       case _: PointerEvent.Move
           if (context.isActive || model.isDragged) && model.isDown && model.dragOptions.isDraggable =>

--- a/indigo-extras/src/indigoextras/ui/components/Button.scala
+++ b/indigo-extras/src/indigoextras/ui/components/Button.scala
@@ -238,52 +238,51 @@ object Button:
             case _ =>
               model.bounds
 
-        val decideState: ButtonState =
-          if context.isActive || model.isDragged then
-            if model.isDown then ButtonState.Down
-            else if newBounds
-                .moveBy(context.parent.coords + context.parent.additionalOffset)
-                .contains(context.pointerCoords)
-            then
-              if context.frame.input.pointer.isDown then ButtonState.Down
-              else ButtonState.Over
-            else ButtonState.Up
-          else ButtonState.Up
-
         Outcome(
           model.copy(
-            state = decideState,
-            isOver = decideState != ButtonState.Up,
             bounds = newBounds
           )
-        ).addGlobalEvents(
-          if decideState == ButtonState.Over && !model.isOver then model.enter(context.reference)
-          else if decideState == ButtonState.Up && model.isOver then model.leave(context.reference)
-          else Batch.empty
         )
 
       case FocusEvent.LostFocus | FocusEvent.ApplicationLostFocus =>
         Outcome(model.copy(state = ButtonState.Up, isDown = false, isOver = false, dragStart = None))
 
-      case _: PointerEvent.Click
-          if context.isActive && model.bounds
-            .moveBy(context.parent.coords + context.parent.additionalOffset)
-            .contains(context.pointerCoords) =>
-        Outcome(model.copy(state = ButtonState.Up, isDown = false, dragStart = None))
+      case _: PointerEvent.Enter
+          if context.isActive && !model.isDown && coordsInBounds(context.pointerCoords, model.bounds, context) =>
+        Outcome(model.copy(state = ButtonState.Over, isOver = true))
+          .addGlobalEvents(
+            if model.isOver then Batch.empty else model.enter(context.reference)
+          )
+
+      case _: PointerEvent.Leave if model.isOver =>
+        Outcome(model.copy(state = if model.isDown then ButtonState.Down else ButtonState.Up, isOver = false))
+          .addGlobalEvents(model.leave(context.reference))
+
+      case _: PointerEvent.Leave =>
+        Outcome(model)
+
+      case _: PointerEvent.Move
+          if context.isActive && !model.isDown && model.isOver &&
+            !coordsInBounds(context.pointerCoords, model.bounds, context) =>
+        Outcome(model.copy(state = ButtonState.Up, isOver = false))
+          .addGlobalEvents(model.leave(context.reference))
+
+      case _: PointerEvent.Move
+          if context.isActive && !model.isDown && !model.isOver &&
+            coordsInBounds(context.pointerCoords, model.bounds, context) =>
+        Outcome(model.copy(state = ButtonState.Over, isOver = true))
+          .addGlobalEvents(model.enter(context.reference))
+
+      case _: PointerEvent.Click if context.isActive && coordsInBounds(context.pointerCoords, model.bounds, context) =>
+        Outcome(model.copy(state = ButtonState.Over, isDown = false, isOver = true, dragStart = None))
           .addGlobalEvents(model.click(context.reference))
 
-      case _: PointerEvent.Down
-          if context.isActive && model.bounds
-            .moveBy(context.parent.coords + context.parent.additionalOffset)
-            .contains(context.pointerCoords) =>
-        Outcome(model.copy(state = ButtonState.Down, isDown = true, dragStart = None))
+      case _: PointerEvent.Down if context.isActive && coordsInBounds(context.pointerCoords, model.bounds, context) =>
+        Outcome(model.copy(state = ButtonState.Down, isDown = true, isOver = true, dragStart = None))
           .addGlobalEvents(model.press(context.reference))
 
-      case _: PointerEvent.Up
-          if context.isActive && model.bounds
-            .moveBy(context.parent.coords + context.parent.additionalOffset)
-            .contains(context.pointerCoords) =>
-        Outcome(model.copy(state = ButtonState.Up, isDown = false, dragStart = None))
+      case _: PointerEvent.Up if context.isActive && coordsInBounds(context.pointerCoords, model.bounds, context) =>
+        Outcome(model.copy(state = ButtonState.Over, isDown = false, isOver = true, dragStart = None))
           .addGlobalEvents(model.release(context.reference))
 
       case _: PointerEvent.Up =>
@@ -326,6 +325,14 @@ object Button:
 
       case _ =>
         Outcome(model)
+
+    override def hitTest(context: UIContext[ReferenceData], model: Button[ReferenceData]): Boolean =
+      coordsInBounds(context.pointerCoords, model.bounds, context)
+
+    override def hitTest(context: UIContext[ReferenceData], model: Button[ReferenceData], event: GlobalEvent): Boolean =
+      event match
+        case _: WheelEvent => false
+        case _             => hitTest(context, model)
 
     def present(
         context: UIContext[ReferenceData],
@@ -391,6 +398,12 @@ object Button:
               context.parent.bounds.height - padding.top - padding.bottom
             )
           )
+
+    private def coordsInBounds(pnt: Coords, bounds: Bounds, context: UIContext[ReferenceData]): Boolean =
+      context.pointerIsWithinInputClip &&
+        bounds
+          .moveBy(context.parent.coords + context.parent.additionalOffset)
+          .contains(pnt)
 
 enum ButtonState derives CanEqual:
   case Up, Over, Down

--- a/indigo-extras/src/indigoextras/ui/components/ComponentGroup.scala
+++ b/indigo-extras/src/indigoextras/ui/components/ComponentGroup.scala
@@ -164,14 +164,14 @@ object ComponentGroup:
           }
         )
 
-    def hitTest(
+    override def hitTest(
         context: UIContext[ReferenceData],
         model: ComponentGroup[ReferenceData],
         event: GlobalEvent
     ): Boolean =
       ContainerLikeFunctions.hitTest(context, model.components, event)
 
-    def hasPointerCapture(context: UIContext[ReferenceData], model: ComponentGroup[ReferenceData]): Boolean =
+    override def hasPointerCapture(context: UIContext[ReferenceData], model: ComponentGroup[ReferenceData]): Boolean =
       ContainerLikeFunctions.hasPointerCapture(context, model.components)
 
     def present(

--- a/indigo-extras/src/indigoextras/ui/components/ComponentGroup.scala
+++ b/indigo-extras/src/indigoextras/ui/components/ComponentGroup.scala
@@ -174,6 +174,9 @@ object ComponentGroup:
     ): Boolean =
       ContainerLikeFunctions.hitTest(context, model.components, event)
 
+    override def hasPointerCapture(context: UIContext[ReferenceData], model: ComponentGroup[ReferenceData]): Boolean =
+      ContainerLikeFunctions.hasPointerCapture(context, model.components)
+
     def present(
         context: UIContext[ReferenceData],
         model: ComponentGroup[ReferenceData]

--- a/indigo-extras/src/indigoextras/ui/components/ComponentGroup.scala
+++ b/indigo-extras/src/indigoextras/ui/components/ComponentGroup.scala
@@ -165,14 +165,14 @@ object ComponentGroup:
         )
 
     override def hitTest(context: UIContext[ReferenceData], model: ComponentGroup[ReferenceData]): Boolean =
-      ContainerLikeFunctions.hitTest(context, model.dimensions, model.components)
+      ContainerLikeFunctions.hitTest(context, model.components)
 
     override def hitTest(
         context: UIContext[ReferenceData],
         model: ComponentGroup[ReferenceData],
         event: GlobalEvent
     ): Boolean =
-      ContainerLikeFunctions.hitTest(context, model.dimensions, model.components, event)
+      ContainerLikeFunctions.hitTest(context, model.components, event)
 
     def present(
         context: UIContext[ReferenceData],

--- a/indigo-extras/src/indigoextras/ui/components/ComponentGroup.scala
+++ b/indigo-extras/src/indigoextras/ui/components/ComponentGroup.scala
@@ -164,17 +164,14 @@ object ComponentGroup:
           }
         )
 
-    override def hitTest(context: UIContext[ReferenceData], model: ComponentGroup[ReferenceData]): Boolean =
-      ContainerLikeFunctions.hitTest(context, model.components)
-
-    override def hitTest(
+    def hitTest(
         context: UIContext[ReferenceData],
         model: ComponentGroup[ReferenceData],
         event: GlobalEvent
     ): Boolean =
       ContainerLikeFunctions.hitTest(context, model.components, event)
 
-    override def hasPointerCapture(context: UIContext[ReferenceData], model: ComponentGroup[ReferenceData]): Boolean =
+    def hasPointerCapture(context: UIContext[ReferenceData], model: ComponentGroup[ReferenceData]): Boolean =
       ContainerLikeFunctions.hasPointerCapture(context, model.components)
 
     def present(

--- a/indigo-extras/src/indigoextras/ui/components/ComponentGroup.scala
+++ b/indigo-extras/src/indigoextras/ui/components/ComponentGroup.scala
@@ -154,25 +154,25 @@ object ComponentGroup:
         context: UIContext[ReferenceData],
         model: ComponentGroup[ReferenceData]
     ): GlobalEvent => Outcome[ComponentGroup[ReferenceData]] =
-      e =>
-        model.components
-          .map { c =>
-            c.component
-              .updateModel(
-                context
-                  .withParentBounds(Bounds(context.parent.bounds.moveBy(c.offset).coords, model.dimensions)),
-                c.model
-              )(e)
-              .map { updated =>
-                c.copy(model = updated)
-              }
-          }
-          .sequence
-          .map { updatedComponents =>
+      ContainerLikeFunctions
+        .routeOrBroadcast(context, model.dimensions, model.components)
+        .andThen(
+          _.map { updatedComponents =>
             model.copy(
               components = updatedComponents
             )
           }
+        )
+
+    override def hitTest(context: UIContext[ReferenceData], model: ComponentGroup[ReferenceData]): Boolean =
+      ContainerLikeFunctions.hitTest(context, model.dimensions, model.components)
+
+    override def hitTest(
+        context: UIContext[ReferenceData],
+        model: ComponentGroup[ReferenceData],
+        event: GlobalEvent
+    ): Boolean =
+      ContainerLikeFunctions.hitTest(context, model.dimensions, model.components, event)
 
     def present(
         context: UIContext[ReferenceData],

--- a/indigo-extras/src/indigoextras/ui/components/ComponentList.scala
+++ b/indigo-extras/src/indigoextras/ui/components/ComponentList.scala
@@ -193,6 +193,27 @@ object ComponentList:
 
       ContainerLikeFunctions.hitTest(context, entries, event)
 
+    override def hasPointerCapture(
+        context: UIContext[ReferenceData],
+        model: ComponentList[ReferenceData]
+    ): Boolean =
+      val entries =
+        contentReflow(
+          context,
+          model.dimensions,
+          model.layout,
+          model.content(context).map { entry =>
+            model.stateMap.get(entry.id) match
+              case None =>
+                entry
+
+              case Some(savedState) =>
+                entry.copy(model = savedState.asInstanceOf[entry.Out])
+          }
+        )
+
+      ContainerLikeFunctions.hasPointerCapture(context, entries)
+
     def present(
         context: UIContext[ReferenceData],
         model: ComponentList[ReferenceData]

--- a/indigo-extras/src/indigoextras/ui/components/ComponentList.scala
+++ b/indigo-extras/src/indigoextras/ui/components/ComponentList.scala
@@ -18,21 +18,6 @@ final case class ComponentList[ReferenceData] private[components] (
     dimensions: Dimensions,
     background: Bounds => Layer
 ):
-
-  private def addSingle[A](entry: UIContext[ReferenceData] => (ComponentId, A))(using
-      c: Component[A, ReferenceData]
-  ): ComponentList[ReferenceData] =
-    val f =
-      (ctx: UIContext[ReferenceData]) =>
-        content(ctx) :+ {
-          val (id, a) = entry(ctx)
-          ComponentEntry(id, Coords.zero, a, c, None)
-        }
-
-    this.copy(
-      content = f
-    )
-
   def addOne[A](entry: UIContext[ReferenceData] => (ComponentId, A))(using
       c: Component[A, ReferenceData]
   ): ComponentList[ReferenceData] =
@@ -140,100 +125,37 @@ object ComponentList:
         model: ComponentList[ReferenceData]
     ): GlobalEvent => Outcome[ComponentList[ReferenceData]] =
       case e =>
-        // What we're doing here it updating the stateMap, not the content function.
-        // However, to do that properly, we need to reflow the content too, to make sure things
-        // like pointer clicks are still in the right place.
-        val entries =
-          contentReflow(
-            context,
-            model.dimensions,
-            model.layout,
-            model.content(context).map { entry =>
-              model.stateMap.get(entry.id) match
-                case None =>
-                  entry
-
-                case Some(savedState) =>
-                  entry.copy(model = savedState.asInstanceOf[entry.Out])
-            }
-          )
-
         val nextStateMap =
           ContainerLikeFunctions
-            .routeOrBroadcast(context, model.dimensions, entries)(e)
+            .routeOrBroadcast(context, model.dimensions, entries(context, model))(e)
             .map(_.map(e => e.id -> e.model).toMap)
 
         nextStateMap.map { newStateMap =>
           model.copy(stateMap = newStateMap)
         }
 
-    def hitTest(
+    override def hitTest(
         context: UIContext[ReferenceData],
         model: ComponentList[ReferenceData],
         event: GlobalEvent
     ): Boolean =
-      val entries =
-        contentReflow(
-          context,
-          model.dimensions,
-          model.layout,
-          model.content(context).map { entry =>
-            model.stateMap.get(entry.id) match
-              case None =>
-                entry
+      ContainerLikeFunctions.hitTest(context, entries(context, model), event)
 
-              case Some(savedState) =>
-                entry.copy(model = savedState.asInstanceOf[entry.Out])
-          }
-        )
-
-      ContainerLikeFunctions.hitTest(context, entries, event)
-
-    def hasPointerCapture(
+    override def hasPointerCapture(
         context: UIContext[ReferenceData],
         model: ComponentList[ReferenceData]
     ): Boolean =
-      val entries =
-        contentReflow(
-          context,
-          model.dimensions,
-          model.layout,
-          model.content(context).map { entry =>
-            model.stateMap.get(entry.id) match
-              case None =>
-                entry
-
-              case Some(savedState) =>
-                entry.copy(model = savedState.asInstanceOf[entry.Out])
-          }
-        )
-
-      ContainerLikeFunctions.hasPointerCapture(context, entries)
+      ContainerLikeFunctions.hasPointerCapture(context, entries(context, model))
 
     def present(
         context: UIContext[ReferenceData],
         model: ComponentList[ReferenceData]
     ): Outcome[Layer] =
-      // Pull the state out of the stateMap and present it
-      val entries =
-        model
-          .content(context)
-          .map { entry =>
-            model.stateMap.get(entry.id) match
-              case None =>
-                // No entry, so we use the default.
-                entry
-
-              case Some(savedState) =>
-                // We have an entry, so overwrite the model with it.
-                entry.copy(model = savedState.asInstanceOf[entry.Out])
-          }
-
       ContainerLikeFunctions
         .present(
           context,
           model.dimensions,
-          contentReflow(context, model.dimensions, model.layout, entries)
+          entries(context, model)
         )
         .map { components =>
           val background = model.background(Bounds(context.parent.coords, model.dimensions))
@@ -248,6 +170,27 @@ object ComponentList:
         model: ComponentList[ReferenceData]
     ): ComponentList[ReferenceData] =
       model
+
+    /** Rebuilds the entries from the content function, restoring each child's last known state from the stateMap, and
+      * reflows their layout offsets so that things like pointer clicks land in the right place.
+      */
+    private def entries(
+        context: UIContext[ReferenceData],
+        model: ComponentList[ReferenceData]
+    ): Batch[ComponentEntry[?, ReferenceData]] =
+      contentReflow(
+        context,
+        model.dimensions,
+        model.layout,
+        model.content(context).map { entry =>
+          model.stateMap.get(entry.id) match
+            case None =>
+              entry
+
+            case Some(savedState) =>
+              entry.copy(model = savedState.asInstanceOf[entry.Out])
+        }
+      )
 
     private def contentReflow(
         context: UIContext[ReferenceData],

--- a/indigo-extras/src/indigoextras/ui/components/ComponentList.scala
+++ b/indigo-extras/src/indigoextras/ui/components/ComponentList.scala
@@ -153,25 +153,7 @@ object ComponentList:
           model.copy(stateMap = newStateMap)
         }
 
-    override def hitTest(context: UIContext[ReferenceData], model: ComponentList[ReferenceData]): Boolean =
-      val entries =
-        contentReflow(
-          context,
-          model.dimensions,
-          model.layout,
-          model.content(context).map { entry =>
-            model.stateMap.get(entry.id) match
-              case None =>
-                entry
-
-              case Some(savedState) =>
-                entry.copy(model = savedState.asInstanceOf[entry.Out])
-          }
-        )
-
-      ContainerLikeFunctions.hitTest(context, entries)
-
-    override def hitTest(
+    def hitTest(
         context: UIContext[ReferenceData],
         model: ComponentList[ReferenceData],
         event: GlobalEvent
@@ -193,7 +175,7 @@ object ComponentList:
 
       ContainerLikeFunctions.hitTest(context, entries, event)
 
-    override def hasPointerCapture(
+    def hasPointerCapture(
         context: UIContext[ReferenceData],
         model: ComponentList[ReferenceData]
     ): Boolean =

--- a/indigo-extras/src/indigoextras/ui/components/ComponentList.scala
+++ b/indigo-extras/src/indigoextras/ui/components/ComponentList.scala
@@ -169,7 +169,7 @@ object ComponentList:
           }
         )
 
-      ContainerLikeFunctions.hitTest(context, model.dimensions, entries)
+      ContainerLikeFunctions.hitTest(context, entries)
 
     override def hitTest(
         context: UIContext[ReferenceData],
@@ -191,7 +191,7 @@ object ComponentList:
           }
         )
 
-      ContainerLikeFunctions.hitTest(context, model.dimensions, entries, event)
+      ContainerLikeFunctions.hitTest(context, entries, event)
 
     def present(
         context: UIContext[ReferenceData],

--- a/indigo-extras/src/indigoextras/ui/components/ComponentList.scala
+++ b/indigo-extras/src/indigoextras/ui/components/ComponentList.scala
@@ -129,47 +129,69 @@ object ComponentList:
         // What we're doing here it updating the stateMap, not the content function.
         // However, to do that properly, we need to reflow the content too, to make sure things
         // like pointer clicks are still in the right place.
-        val nextOffset =
-          ContainerLikeFunctions
-            .calculateNextOffset[ReferenceData](model.dimensions, model.layout)
-
         val entries =
-          model.content(context)
+          contentReflow(
+            context,
+            model.dimensions,
+            model.layout,
+            model.content(context).map { entry =>
+              model.stateMap.get(entry.id) match
+                case None =>
+                  entry
+
+                case Some(savedState) =>
+                  entry.copy(model = savedState.asInstanceOf[entry.Out])
+            }
+          )
 
         val nextStateMap =
-          entries
-            .foldLeft(Outcome(Batch.empty[ComponentEntry[?, ReferenceData]])) { (accum, entry) =>
-              accum.flatMap { acc =>
-                val offset = nextOffset(context, acc)
-
-                val updated =
-                  model.stateMap.get(entry.id) match
-                    case None =>
-                      // No entry, so we make one based on the component's default state
-                      entry.component
-                        .updateModel(
-                          context.withParentBounds(context.parent.bounds.moveBy(offset)),
-                          entry.model
-                        )(e)
-                        .map(m => entry.copy(offset = offset, model = m))
-
-                    case Some(savedState) =>
-                      // We have an entry, so we update it
-                      entry.component
-                        .updateModel(
-                          context.withParentBounds(context.parent.bounds.moveBy(offset)),
-                          savedState.asInstanceOf[entry.Out]
-                        )(e)
-                        .map(m => entry.copy(offset = offset, model = m))
-
-                updated.map(u => acc :+ u)
-              }
-            }
+          ContainerLikeFunctions
+            .routeOrBroadcast(context, model.dimensions, entries)(e)
             .map(_.map(e => e.id -> e.model).toMap)
 
         nextStateMap.map { newStateMap =>
           model.copy(stateMap = newStateMap)
         }
+
+    override def hitTest(context: UIContext[ReferenceData], model: ComponentList[ReferenceData]): Boolean =
+      val entries =
+        contentReflow(
+          context,
+          model.dimensions,
+          model.layout,
+          model.content(context).map { entry =>
+            model.stateMap.get(entry.id) match
+              case None =>
+                entry
+
+              case Some(savedState) =>
+                entry.copy(model = savedState.asInstanceOf[entry.Out])
+          }
+        )
+
+      ContainerLikeFunctions.hitTest(context, model.dimensions, entries)
+
+    override def hitTest(
+        context: UIContext[ReferenceData],
+        model: ComponentList[ReferenceData],
+        event: GlobalEvent
+    ): Boolean =
+      val entries =
+        contentReflow(
+          context,
+          model.dimensions,
+          model.layout,
+          model.content(context).map { entry =>
+            model.stateMap.get(entry.id) match
+              case None =>
+                entry
+
+              case Some(savedState) =>
+                entry.copy(model = savedState.asInstanceOf[entry.Out])
+          }
+        )
+
+      ContainerLikeFunctions.hitTest(context, model.dimensions, entries, event)
 
     def present(
         context: UIContext[ReferenceData],

--- a/indigo-extras/src/indigoextras/ui/components/ComponentList.scala
+++ b/indigo-extras/src/indigoextras/ui/components/ComponentList.scala
@@ -79,6 +79,20 @@ final case class ComponentList[ReferenceData] private[components] (
   def withBackground(present: Bounds => Layer): ComponentList[ReferenceData] =
     this.copy(background = present)
 
+  private def addSingle[A](entry: UIContext[ReferenceData] => (ComponentId, A))(using
+      c: Component[A, ReferenceData]
+  ): ComponentList[ReferenceData] =
+    val f =
+      (ctx: UIContext[ReferenceData]) =>
+        content(ctx) :+ {
+          val (id, a) = entry(ctx)
+          ComponentEntry(id, Coords.zero, a, c, None)
+        }
+
+    this.copy(
+      content = f
+    )
+
 object ComponentList:
 
   def apply[ReferenceData, A](

--- a/indigo-extras/src/indigoextras/ui/components/HitArea.scala
+++ b/indigo-extras/src/indigoextras/ui/components/HitArea.scala
@@ -206,6 +206,12 @@ object HitArea:
         val s = model.stroke
         btn.updateModel(context, model.toButton)(e).map(_.toHitArea.copy(fill = f, stroke = s))
 
+    override def hitTest(context: UIContext[ReferenceData], model: HitArea[ReferenceData]): Boolean =
+      btn.hitTest(context, model.toButton)
+
+    override def hitTest(context: UIContext[ReferenceData], model: HitArea[ReferenceData], event: GlobalEvent): Boolean =
+      btn.hitTest(context, model.toButton, event)
+
     def present(
         context: UIContext[ReferenceData],
         model: HitArea[ReferenceData]

--- a/indigo-extras/src/indigoextras/ui/components/HitArea.scala
+++ b/indigo-extras/src/indigoextras/ui/components/HitArea.scala
@@ -216,6 +216,9 @@ object HitArea:
     ): Boolean =
       btn.hitTest(context, model.toButton, event)
 
+    override def hasPointerCapture(context: UIContext[ReferenceData], model: HitArea[ReferenceData]): Boolean =
+      btn.hasPointerCapture(context, model.toButton)
+
     def present(
         context: UIContext[ReferenceData],
         model: HitArea[ReferenceData]

--- a/indigo-extras/src/indigoextras/ui/components/HitArea.scala
+++ b/indigo-extras/src/indigoextras/ui/components/HitArea.scala
@@ -209,7 +209,11 @@ object HitArea:
     override def hitTest(context: UIContext[ReferenceData], model: HitArea[ReferenceData]): Boolean =
       btn.hitTest(context, model.toButton)
 
-    override def hitTest(context: UIContext[ReferenceData], model: HitArea[ReferenceData], event: GlobalEvent): Boolean =
+    override def hitTest(
+        context: UIContext[ReferenceData],
+        model: HitArea[ReferenceData],
+        event: GlobalEvent
+    ): Boolean =
       btn.hitTest(context, model.toButton, event)
 
     def present(

--- a/indigo-extras/src/indigoextras/ui/components/HitArea.scala
+++ b/indigo-extras/src/indigoextras/ui/components/HitArea.scala
@@ -206,17 +206,14 @@ object HitArea:
         val s = model.stroke
         btn.updateModel(context, model.toButton)(e).map(_.toHitArea.copy(fill = f, stroke = s))
 
-    override def hitTest(context: UIContext[ReferenceData], model: HitArea[ReferenceData]): Boolean =
-      btn.hitTest(context, model.toButton)
-
-    override def hitTest(
+    def hitTest(
         context: UIContext[ReferenceData],
         model: HitArea[ReferenceData],
         event: GlobalEvent
     ): Boolean =
       btn.hitTest(context, model.toButton, event)
 
-    override def hasPointerCapture(context: UIContext[ReferenceData], model: HitArea[ReferenceData]): Boolean =
+    def hasPointerCapture(context: UIContext[ReferenceData], model: HitArea[ReferenceData]): Boolean =
       btn.hasPointerCapture(context, model.toButton)
 
     def present(

--- a/indigo-extras/src/indigoextras/ui/components/HitArea.scala
+++ b/indigo-extras/src/indigoextras/ui/components/HitArea.scala
@@ -206,14 +206,14 @@ object HitArea:
         val s = model.stroke
         btn.updateModel(context, model.toButton)(e).map(_.toHitArea.copy(fill = f, stroke = s))
 
-    def hitTest(
+    override def hitTest(
         context: UIContext[ReferenceData],
         model: HitArea[ReferenceData],
         event: GlobalEvent
     ): Boolean =
       btn.hitTest(context, model.toButton, event)
 
-    def hasPointerCapture(context: UIContext[ReferenceData], model: HitArea[ReferenceData]): Boolean =
+    override def hasPointerCapture(context: UIContext[ReferenceData], model: HitArea[ReferenceData]): Boolean =
       btn.hasPointerCapture(context, model.toButton)
 
     def present(

--- a/indigo-extras/src/indigoextras/ui/components/Input.scala
+++ b/indigo-extras/src/indigoextras/ui/components/Input.scala
@@ -192,13 +192,13 @@ object Input:
       case _ =>
         Outcome(model)
 
-    override def hitTest(context: UIContext[ReferenceData], model: Input[ReferenceData]): Boolean =
-      coordsInBounds(context.pointerCoords, Bounds(model.dimensions), context)
-
-    override def hitTest(context: UIContext[ReferenceData], model: Input[ReferenceData], event: GlobalEvent): Boolean =
+    def hitTest(context: UIContext[ReferenceData], model: Input[ReferenceData], event: GlobalEvent): Boolean =
       event match
         case _: WheelEvent => false
-        case _             => hitTest(context, model)
+        case _             => coordsInBounds(context.pointerCoords, Bounds(model.dimensions), context)
+
+    def hasPointerCapture(context: UIContext[ReferenceData], model: Input[ReferenceData]): Boolean =
+      false
 
     def present(
         context: UIContext[ReferenceData],
@@ -287,7 +287,7 @@ object Input:
   }
 
   private def coordsInBounds[ReferenceData](pnt: Coords, bounds: Bounds, context: UIContext[ReferenceData]): Boolean =
-    context.pointerIsWithinInputClip &&
+    context.pointerIsWithinActiveInputBounds &&
       bounds
         .moveBy(context.parent.coords + context.parent.additionalOffset)
         .contains(pnt)

--- a/indigo-extras/src/indigoextras/ui/components/Input.scala
+++ b/indigo-extras/src/indigoextras/ui/components/Input.scala
@@ -143,9 +143,7 @@ object Input:
         model: Input[ReferenceData]
     ): GlobalEvent => Outcome[Input[ReferenceData]] =
       case _: PointerEvent.Click
-          if context.isActive && Bounds(model.dimensions)
-            .moveBy(context.parent.coords)
-            .contains(context.pointerCoords) =>
+          if context.isActive && coordsInBounds(context.pointerCoords, Bounds(model.dimensions), context) =>
 
         val cursorPos = Input.findCursorPosition(
           context.pointerCoords.x - context.parent.coords.x,
@@ -193,6 +191,14 @@ object Input:
 
       case _ =>
         Outcome(model)
+
+    override def hitTest(context: UIContext[ReferenceData], model: Input[ReferenceData]): Boolean =
+      coordsInBounds(context.pointerCoords, Bounds(model.dimensions), context)
+
+    override def hitTest(context: UIContext[ReferenceData], model: Input[ReferenceData], event: GlobalEvent): Boolean =
+      event match
+        case _: WheelEvent => false
+        case _             => hitTest(context, model)
 
     def present(
         context: UIContext[ReferenceData],
@@ -279,5 +285,11 @@ object Input:
 
     rec(textToInsert.toCharArray().toList, splitString._1, splitString._2, correctedPosition)
   }
+
+  private def coordsInBounds[ReferenceData](pnt: Coords, bounds: Bounds, context: UIContext[ReferenceData]): Boolean =
+    context.pointerIsWithinInputClip &&
+      bounds
+        .moveBy(context.parent.coords + context.parent.additionalOffset)
+        .contains(pnt)
 
 final case class InputTextModified(updatedText: String, nextCursorPosition: Int)

--- a/indigo-extras/src/indigoextras/ui/components/Input.scala
+++ b/indigo-extras/src/indigoextras/ui/components/Input.scala
@@ -142,8 +142,7 @@ object Input:
         context: UIContext[ReferenceData],
         model: Input[ReferenceData]
     ): GlobalEvent => Outcome[Input[ReferenceData]] =
-      case _: PointerEvent.Click
-          if context.isActive && coordsInBounds(context.pointerCoords, Bounds(model.dimensions), context) =>
+      case _: PointerEvent.Click if context.isActive && coordsInBounds(context.pointerCoords, context, model) =>
 
         val cursorPos = Input.findCursorPosition(
           context.pointerCoords.x - context.parent.coords.x,
@@ -191,14 +190,6 @@ object Input:
 
       case _ =>
         Outcome(model)
-
-    def hitTest(context: UIContext[ReferenceData], model: Input[ReferenceData], event: GlobalEvent): Boolean =
-      event match
-        case _: WheelEvent => false
-        case _             => coordsInBounds(context.pointerCoords, Bounds(model.dimensions), context)
-
-    def hasPointerCapture(context: UIContext[ReferenceData], model: Input[ReferenceData]): Boolean =
-      false
 
     def present(
         context: UIContext[ReferenceData],
@@ -285,11 +276,5 @@ object Input:
 
     rec(textToInsert.toCharArray().toList, splitString._1, splitString._2, correctedPosition)
   }
-
-  private def coordsInBounds[ReferenceData](pnt: Coords, bounds: Bounds, context: UIContext[ReferenceData]): Boolean =
-    context.pointerIsWithinActiveInputBounds &&
-      bounds
-        .moveBy(context.parent.coords + context.parent.additionalOffset)
-        .contains(pnt)
 
 final case class InputTextModified(updatedText: String, nextCursorPosition: Int)

--- a/indigo-extras/src/indigoextras/ui/components/Label.scala
+++ b/indigo-extras/src/indigoextras/ui/components/Label.scala
@@ -6,6 +6,7 @@ import indigoextras.ui.datatypes.Bounds
 import indigoextras.ui.datatypes.UIContext
 
 import scala.annotation.targetName
+import indigoextras.ui.datatypes.Coords
 
 /** Labels are a simple `Component` that render text.
   */
@@ -97,3 +98,17 @@ object Label:
         model: Label[ReferenceData]
     ): Label[ReferenceData] =
       model
+
+    def hitTest(context: UIContext[ReferenceData], model: Label[ReferenceData], event: GlobalEvent): Boolean =
+      event match
+        case _: WheelEvent => false
+        case _ => coordsInBounds(context.pointerCoords, model.calculateBounds(context, model.text(context)), context)
+
+    def hasPointerCapture(context: UIContext[ReferenceData], model: Label[ReferenceData]): Boolean =
+      false
+
+    private def coordsInBounds[ReferenceData](pnt: Coords, bounds: Bounds, context: UIContext[ReferenceData]): Boolean =
+      context.pointerIsWithinActiveInputBounds &&
+        bounds
+          .moveBy(context.parent.coords + context.parent.additionalOffset)
+          .contains(pnt)

--- a/indigo-extras/src/indigoextras/ui/components/Label.scala
+++ b/indigo-extras/src/indigoextras/ui/components/Label.scala
@@ -3,10 +3,10 @@ package indigoextras.ui.components
 import indigo.*
 import indigoextras.ui.component.Component
 import indigoextras.ui.datatypes.Bounds
+import indigoextras.ui.datatypes.Coords
 import indigoextras.ui.datatypes.UIContext
 
 import scala.annotation.targetName
-import indigoextras.ui.datatypes.Coords
 
 /** Labels are a simple `Component` that render text.
   */
@@ -99,16 +99,5 @@ object Label:
     ): Label[ReferenceData] =
       model
 
-    def hitTest(context: UIContext[ReferenceData], model: Label[ReferenceData], event: GlobalEvent): Boolean =
-      event match
-        case _: WheelEvent => false
-        case _ => coordsInBounds(context.pointerCoords, model.calculateBounds(context, model.text(context)), context)
-
-    def hasPointerCapture(context: UIContext[ReferenceData], model: Label[ReferenceData]): Boolean =
+    override def hitTest(context: UIContext[ReferenceData], model: Label[ReferenceData], event: GlobalEvent): Boolean =
       false
-
-    private def coordsInBounds[ReferenceData](pnt: Coords, bounds: Bounds, context: UIContext[ReferenceData]): Boolean =
-      context.pointerIsWithinActiveInputBounds &&
-        bounds
-          .moveBy(context.parent.coords + context.parent.additionalOffset)
-          .contains(pnt)

--- a/indigo-extras/src/indigoextras/ui/components/MaskedPane.scala
+++ b/indigo-extras/src/indigoextras/ui/components/MaskedPane.scala
@@ -119,7 +119,7 @@ object MaskedPane:
     ): GlobalEvent => Outcome[MaskedPane[A, ReferenceData]] =
       case e =>
         val adjustBounds = Bounds(context.parent.bounds.coords, model.dimensions)
-        val ctx          = context.withParentBounds(adjustBounds).pushInputClip(adjustBounds)
+        val ctx          = context.withParentBounds(adjustBounds).pushActiveInputBounds(adjustBounds)
 
         ContainerLikeFunctions
           .routeOrBroadcast(ctx, model.dimensions, Batch(model.content))(e)
@@ -133,22 +133,13 @@ object MaskedPane:
               .getOrElse(model)
           }
 
-    override def hitTest(context: UIContext[ReferenceData], model: MaskedPane[A, ReferenceData]): Boolean =
-      val adjustBounds = Bounds(context.parent.bounds.coords, model.dimensions)
-      val ctx          = context.withParentBounds(adjustBounds).pushInputClip(adjustBounds)
-
-      ContainerLikeFunctions.hitTest(
-        ctx,
-        Batch(model.content)
-      )
-
-    override def hitTest(
+    def hitTest(
         context: UIContext[ReferenceData],
         model: MaskedPane[A, ReferenceData],
         event: GlobalEvent
     ): Boolean =
       val adjustBounds = Bounds(context.parent.bounds.coords, model.dimensions)
-      val ctx          = context.withParentBounds(adjustBounds).pushInputClip(adjustBounds)
+      val ctx          = context.withParentBounds(adjustBounds).pushActiveInputBounds(adjustBounds)
 
       ContainerLikeFunctions.hitTest(
         ctx,
@@ -156,12 +147,12 @@ object MaskedPane:
         event
       )
 
-    override def hasPointerCapture(
+    def hasPointerCapture(
         context: UIContext[ReferenceData],
         model: MaskedPane[A, ReferenceData]
     ): Boolean =
       val adjustBounds = Bounds(context.parent.bounds.coords, model.dimensions)
-      val ctx          = context.withParentBounds(adjustBounds).pushInputClip(adjustBounds)
+      val ctx          = context.withParentBounds(adjustBounds).pushActiveInputBounds(adjustBounds)
 
       ContainerLikeFunctions.hasPointerCapture(ctx, Batch(model.content))
 
@@ -170,7 +161,7 @@ object MaskedPane:
         model: MaskedPane[A, ReferenceData]
     ): Outcome[Layer] =
       val adjustBounds = Bounds(context.parent.bounds.coords, model.dimensions)
-      val ctx          = context.withParentBounds(adjustBounds).pushInputClip(adjustBounds)
+      val ctx          = context.withParentBounds(adjustBounds).pushActiveInputBounds(adjustBounds)
 
       val content =
         ContainerLikeFunctions

--- a/indigo-extras/src/indigoextras/ui/components/MaskedPane.scala
+++ b/indigo-extras/src/indigoextras/ui/components/MaskedPane.scala
@@ -139,7 +139,6 @@ object MaskedPane:
 
       ContainerLikeFunctions.hitTest(
         ctx,
-        model.dimensions,
         Batch(model.content)
       )
 
@@ -153,7 +152,6 @@ object MaskedPane:
 
       ContainerLikeFunctions.hitTest(
         ctx,
-        model.dimensions,
         Batch(model.content),
         event
       )

--- a/indigo-extras/src/indigoextras/ui/components/MaskedPane.scala
+++ b/indigo-extras/src/indigoextras/ui/components/MaskedPane.scala
@@ -118,24 +118,52 @@ object MaskedPane:
         model: MaskedPane[A, ReferenceData]
     ): GlobalEvent => Outcome[MaskedPane[A, ReferenceData]] =
       case e =>
-        val ctx = context.withParentBounds(Bounds(context.parent.bounds.coords, model.dimensions))
+        val adjustBounds = Bounds(context.parent.bounds.coords, model.dimensions)
+        val ctx          = context.withParentBounds(adjustBounds).pushInputClip(adjustBounds)
 
-        model.content.component
-          .updateModel(ctx, model.content.model)(e)
-          .flatMap { updatedContent =>
-            Outcome(
-              model.copy(
-                content = model.content.copy(model = updatedContent)
-              )
-            )
+        ContainerLikeFunctions
+          .routeOrBroadcast(ctx, model.dimensions, Batch(model.content))(e)
+          .map { updated =>
+            updated.headOption
+              .map { content =>
+                model.copy(
+                  content = model.content.copy(model = content.model.asInstanceOf[A])
+                )
+              }
+              .getOrElse(model)
           }
+
+    override def hitTest(context: UIContext[ReferenceData], model: MaskedPane[A, ReferenceData]): Boolean =
+      val adjustBounds = Bounds(context.parent.bounds.coords, model.dimensions)
+      val ctx          = context.withParentBounds(adjustBounds).pushInputClip(adjustBounds)
+
+      ContainerLikeFunctions.hitTest(
+        ctx,
+        model.dimensions,
+        Batch(model.content)
+      )
+
+    override def hitTest(
+        context: UIContext[ReferenceData],
+        model: MaskedPane[A, ReferenceData],
+        event: GlobalEvent
+    ): Boolean =
+      val adjustBounds = Bounds(context.parent.bounds.coords, model.dimensions)
+      val ctx          = context.withParentBounds(adjustBounds).pushInputClip(adjustBounds)
+
+      ContainerLikeFunctions.hitTest(
+        ctx,
+        model.dimensions,
+        Batch(model.content),
+        event
+      )
 
     def present(
         context: UIContext[ReferenceData],
         model: MaskedPane[A, ReferenceData]
     ): Outcome[Layer] =
       val adjustBounds = Bounds(context.parent.bounds.coords, model.dimensions)
-      val ctx          = context.withParentBounds(adjustBounds)
+      val ctx          = context.withParentBounds(adjustBounds).pushInputClip(adjustBounds)
 
       val content =
         ContainerLikeFunctions

--- a/indigo-extras/src/indigoextras/ui/components/MaskedPane.scala
+++ b/indigo-extras/src/indigoextras/ui/components/MaskedPane.scala
@@ -133,7 +133,7 @@ object MaskedPane:
               .getOrElse(model)
           }
 
-    def hitTest(
+    override def hitTest(
         context: UIContext[ReferenceData],
         model: MaskedPane[A, ReferenceData],
         event: GlobalEvent
@@ -147,7 +147,7 @@ object MaskedPane:
         event
       )
 
-    def hasPointerCapture(
+    override def hasPointerCapture(
         context: UIContext[ReferenceData],
         model: MaskedPane[A, ReferenceData]
     ): Boolean =

--- a/indigo-extras/src/indigoextras/ui/components/MaskedPane.scala
+++ b/indigo-extras/src/indigoextras/ui/components/MaskedPane.scala
@@ -122,16 +122,8 @@ object MaskedPane:
         val ctx          = context.withParentBounds(adjustBounds).pushActiveInputBounds(adjustBounds)
 
         ContainerLikeFunctions
-          .routeOrBroadcast(ctx, model.dimensions, Batch(model.content))(e)
-          .map { updated =>
-            updated.headOption
-              .map { content =>
-                model.copy(
-                  content = model.content.copy(model = content.model.asInstanceOf[A])
-                )
-              }
-              .getOrElse(model)
-          }
+          .routeOne(ctx, model.dimensions, model.content)(e)
+          .map(updated => model.copy(content = updated))
 
     override def hitTest(
         context: UIContext[ReferenceData],

--- a/indigo-extras/src/indigoextras/ui/components/MaskedPane.scala
+++ b/indigo-extras/src/indigoextras/ui/components/MaskedPane.scala
@@ -156,6 +156,15 @@ object MaskedPane:
         event
       )
 
+    override def hasPointerCapture(
+        context: UIContext[ReferenceData],
+        model: MaskedPane[A, ReferenceData]
+    ): Boolean =
+      val adjustBounds = Bounds(context.parent.bounds.coords, model.dimensions)
+      val ctx          = context.withParentBounds(adjustBounds).pushInputClip(adjustBounds)
+
+      ContainerLikeFunctions.hasPointerCapture(ctx, Batch(model.content))
+
     def present(
         context: UIContext[ReferenceData],
         model: MaskedPane[A, ReferenceData]

--- a/indigo-extras/src/indigoextras/ui/components/ScrollPane.scala
+++ b/indigo-extras/src/indigoextras/ui/components/ScrollPane.scala
@@ -233,14 +233,12 @@ object ScrollPane:
           )
 
         e match
-          case wheel: WheelEvent
-              if model.content.component.hitTest(contentCtx, model.content.model, wheel) =>
+          case wheel: WheelEvent if model.content.component.hitTest(contentCtx, model.content.model, wheel) =>
             routeContent(wheel).map { updatedContent =>
               model.copy(content = updatedContent)
             }
 
-          case WheelEvent.Vertical(deltaY)
-              if model.scrollOptions.isEnabled && ctx.pointerIsWithinInputClip =>
+          case WheelEvent.Vertical(deltaY) if model.scrollOptions.isEnabled && ctx.pointerIsWithinInputClip =>
             val scrollBy =
               val speed =
                 if model.dimensions.height > 0 then model.dimensions.height / 10 else 1
@@ -292,7 +290,7 @@ object ScrollPane:
                   Outcome(model.content)
 
             for {
-              updatedContent <- contentUpdate
+              updatedContent   <- contentUpdate
               updatedScrollBar <- if scrollingActive then updateScrollBar else Outcome(model.scrollBar)
             } yield model.copy(
               content = updatedContent,
@@ -301,7 +299,7 @@ object ScrollPane:
 
           case event =>
             for {
-              updatedContent  <- routeContent(event)
+              updatedContent   <- routeContent(event)
               updatedScrollBar <- if scrollingActive then updateScrollBar else Outcome(model.scrollBar)
             } yield model.copy(
               content = updatedContent,

--- a/indigo-extras/src/indigoextras/ui/components/ScrollPane.scala
+++ b/indigo-extras/src/indigoextras/ui/components/ScrollPane.scala
@@ -214,9 +214,7 @@ object ScrollPane:
           }
 
         def routeContent(event: GlobalEvent): Outcome[ComponentEntry[A, ReferenceData]] =
-          ContainerLikeFunctions
-            .routeOrBroadcast(contentCtx, model.dimensions, Batch(model.content))(event)
-            .map(_.headOption.map(_.asInstanceOf[ComponentEntry[A, ReferenceData]]).getOrElse(model.content))
+          ContainerLikeFunctions.routeOne(contentCtx, model.dimensions, model.content)(event)
 
         def updateContentWith(events: Batch[GlobalEvent]): Outcome[ComponentEntry[A, ReferenceData]] =
           events

--- a/indigo-extras/src/indigoextras/ui/components/ScrollPane.scala
+++ b/indigo-extras/src/indigoextras/ui/components/ScrollPane.scala
@@ -195,34 +195,9 @@ object ScrollPane:
         context: UIContext[ReferenceData],
         model: ScrollPane[A, ReferenceData]
     ): GlobalEvent => Outcome[ScrollPane[A, ReferenceData]] =
-      case WheelEvent.Vertical(deltaY)
-          if model.scrollOptions.isEnabled && Bounds(context.parent.coords, model.dimensions)
-            .contains(context.pointerCoords) =>
-        val scrollBy =
-          val speed =
-            if model.dimensions.height > 0 then model.dimensions.height / 10 else 1
-          val clamped =
-            Math.min(
-              model.scrollOptions.maxScrollSpeed,
-              Math.max(model.scrollOptions.minScrollSpeed, speed)
-            )
-          val coords =
-            if deltaY < 0 then -clamped else clamped
-
-          coords.toDouble / model.dimensions.height.toDouble
-
-        Outcome(
-          model.copy(
-            scrollAmount = Math.min(1.0d, Math.max(0.0d, model.scrollAmount + scrollBy))
-          )
-        )
-
       case e =>
         val scrollingActive =
           model.scrollOptions.isEnabled && model.contentBounds.height > model.dimensions.height
-
-        val ctx =
-          context.withParentBounds(Bounds(context.parent.coords, model.dimensions))
 
         val scrollOffset: Coords =
           if scrollingActive then
@@ -231,6 +206,11 @@ object ScrollPane:
               ((model.dimensions.height.toDouble - model.contentBounds.height.toDouble) * model.scrollAmount).toInt
             )
           else Coords.zero
+
+        val visibleBounds  = Bounds(context.parent.coords, model.dimensions)
+        val scrolledBounds = visibleBounds.moveBy(scrollOffset)
+        val ctx            = context.withParentBounds(visibleBounds).pushInputClip(visibleBounds)
+        val contentCtx     = ctx.withParentBounds(scrolledBounds)
 
         def updateScrollBar: Outcome[Button[Unit]] =
           val c: Component[Button[Unit], Unit] = summon[Component[Button[Unit], Unit]]
@@ -255,24 +235,155 @@ object ScrollPane:
 
           c.updateModel(unitContext, model.scrollBar)(e)
 
-        for {
-          updatedContent <- model.content.component
-            .updateModel(ctx.withParentBounds(ctx.parent.bounds.moveBy(scrollOffset)), model.content.model)(e)
-          updatedScrollBar <- if scrollingActive then updateScrollBar else Outcome(model.scrollBar)
-        } yield model.copy(
-          content = model.content.copy(model = updatedContent),
-          scrollBar = updatedScrollBar
-        )
+        def updateScrollBarWith(events: Batch[GlobalEvent]): Outcome[Button[Unit]] =
+          val c: Component[Button[Unit], Unit] = summon[Component[Button[Unit], Unit]]
+          val unitContext: UIContext[Unit] =
+            ctx
+              .copy(reference = ())
+              .withParent(
+                ctx.parent
+                  .moveBy(
+                    Coords(
+                      model.dimensions.width - model.scrollBar.bounds.width,
+                      0
+                    )
+                  )
+                  .withAdditionalOffset(
+                    Coords(
+                      0,
+                      ((model.dimensions.height - model.scrollBar.bounds.height).toDouble * model.scrollAmount).toInt
+                    )
+                  )
+              )
 
-    def present(
+          events.foldLeft(Outcome(model.scrollBar)) { (acc, event) =>
+            acc.flatMap(c.updateModel(unitContext, _)(event))
+          }
+
+        def routeContent(event: GlobalEvent): Outcome[ComponentEntry[A, ReferenceData]] =
+          ContainerLikeFunctions
+            .routeOrBroadcast(contentCtx, model.dimensions, Batch(model.content))(event)
+            .map(_.headOption.map(_.asInstanceOf[ComponentEntry[A, ReferenceData]]).getOrElse(model.content))
+
+        def updateContentWith(events: Batch[GlobalEvent]): Outcome[ComponentEntry[A, ReferenceData]] =
+          events
+            .foldLeft(Outcome(model.content.model)) { (acc, event) =>
+              acc.flatMap(model.content.component.updateModel(contentCtx, _)(event))
+            }
+            .map(updated => model.content.copy(model = updated))
+
+        def scrollBarHit(event: GlobalEvent): Boolean =
+          scrollingActive && summon[Component[Button[Unit], Unit]].hitTest(
+            ctx
+              .copy(reference = ())
+              .withParent(
+                ctx.parent
+                  .moveBy(
+                    Coords(
+                      model.dimensions.width - model.scrollBar.bounds.width,
+                      0
+                    )
+                  )
+                  .withAdditionalOffset(
+                    Coords(
+                      0,
+                      ((model.dimensions.height - model.scrollBar.bounds.height).toDouble * model.scrollAmount).toInt
+                    )
+                  )
+              ),
+            model.scrollBar,
+            event
+          )
+
+        e match
+          case wheel: WheelEvent
+              if model.content.component.hitTest(contentCtx, model.content.model, wheel) =>
+            routeContent(wheel).map { updatedContent =>
+              model.copy(content = updatedContent)
+            }
+
+          case WheelEvent.Vertical(deltaY)
+              if model.scrollOptions.isEnabled && visibleBounds.contains(context.pointerCoords) =>
+            val scrollBy =
+              val speed =
+                if model.dimensions.height > 0 then model.dimensions.height / 10 else 1
+              val clamped =
+                Math.min(
+                  model.scrollOptions.maxScrollSpeed,
+                  Math.max(model.scrollOptions.minScrollSpeed, speed)
+                )
+              val coords =
+                if deltaY < 0 then -clamped else clamped
+
+              coords.toDouble / model.dimensions.height.toDouble
+
+            Outcome(
+              model.copy(
+                scrollAmount = Math.min(1.0d, Math.max(0.0d, model.scrollAmount + scrollBy))
+              )
+            )
+
+          case move: PointerEvent.Move if scrollBarHit(move) =>
+            for {
+              updatedContent <- updateContentWith(Batch(PointerRouting.leaveFrom(move)))
+              updatedScrollBar <-
+                if scrollingActive then updateScrollBarWith(Batch(PointerRouting.enterFrom(move), move))
+                else Outcome(model.scrollBar)
+            } yield model.copy(
+              content = updatedContent,
+              scrollBar = updatedScrollBar
+            )
+
+          case move: PointerEvent.Move =>
+            for {
+              updatedContent <- routeContent(move)
+              updatedScrollBar <-
+                if scrollingActive then updateScrollBarWith(Batch(PointerRouting.leaveFrom(move), move))
+                else Outcome(model.scrollBar)
+            } yield model.copy(
+              content = updatedContent,
+              scrollBar = updatedScrollBar
+            )
+
+          case pointer: PointerEvent if scrollBarHit(pointer) =>
+            val contentUpdate =
+              pointer match
+                case _: PointerEvent.Up | _: PointerEvent.Cancel | _: PointerEvent.Leave =>
+                  updateContentWith(Batch(pointer))
+
+                case _ =>
+                  Outcome(model.content)
+
+            for {
+              updatedContent <- contentUpdate
+              updatedScrollBar <- if scrollingActive then updateScrollBar else Outcome(model.scrollBar)
+            } yield model.copy(
+              content = updatedContent,
+              scrollBar = updatedScrollBar
+            )
+
+          case event =>
+            for {
+              updatedContent  <- routeContent(event)
+              updatedScrollBar <- if scrollingActive then updateScrollBar else Outcome(model.scrollBar)
+            } yield model.copy(
+              content = updatedContent,
+              scrollBar = updatedScrollBar
+            )
+
+    override def hitTest(
         context: UIContext[ReferenceData],
         model: ScrollPane[A, ReferenceData]
-    ): Outcome[Layer] =
+    ): Boolean =
+      hitTest(context, model, PointerEvent.Move(context.pointerCoords.unsafeToPoint))
+
+    override def hitTest(
+        context: UIContext[ReferenceData],
+        model: ScrollPane[A, ReferenceData],
+        event: GlobalEvent
+    ): Boolean =
       val scrollingActive =
         model.scrollOptions.isEnabled && model.contentBounds.height > model.dimensions.height
-
-      val ctx =
-        context.withParentBounds(Bounds(context.parent.coords, model.dimensions))
 
       val scrollOffset: Coords =
         if scrollingActive then
@@ -282,13 +393,75 @@ object ScrollPane:
           )
         else Coords.zero
 
+      val visibleBounds  = Bounds(context.parent.coords, model.dimensions)
+      val scrolledBounds = visibleBounds.moveBy(scrollOffset)
+      val ctx            = context.withParentBounds(visibleBounds).pushInputClip(visibleBounds)
+      val contentCtx     = ctx.withParentBounds(scrolledBounds)
+
+      val scrollBarHit =
+        scrollingActive && summon[Component[Button[Unit], Unit]].hitTest(
+          ctx
+            .copy(reference = ())
+            .withParent(
+              ctx.parent
+                .moveBy(
+                  Coords(
+                    model.dimensions.width - model.scrollBar.bounds.width,
+                    0
+                  )
+                )
+                .withAdditionalOffset(
+                  Coords(
+                    0,
+                    ((model.dimensions.height - model.scrollBar.bounds.height).toDouble * model.scrollAmount).toInt
+                  )
+                )
+            ),
+          model.scrollBar,
+          event
+        )
+
+      val contentHit =
+        model.content.component.hitTest(contentCtx, model.content.model, event)
+
+      event match
+        case _: WheelEvent =>
+          contentHit || (model.scrollOptions.isEnabled && visibleBounds.contains(context.pointerCoords))
+
+        case _ =>
+          scrollBarHit || contentHit
+
+    def present(
+        context: UIContext[ReferenceData],
+        model: ScrollPane[A, ReferenceData]
+    ): Outcome[Layer] =
+      val scrollingActive =
+        model.scrollOptions.isEnabled && model.contentBounds.height > model.dimensions.height
+
+      val scrollOffset: Coords =
+        if scrollingActive then
+          Coords(
+            0,
+            ((model.dimensions.height.toDouble - model.contentBounds.height.toDouble) * model.scrollAmount).toInt
+          )
+        else Coords.zero
+
+      val visibleBounds  = Bounds(context.parent.coords, model.dimensions)
+      val scrolledBounds = visibleBounds.moveBy(scrollOffset)
+      val contentCtx     =
+        context.withParentBounds(scrolledBounds).pushInputClip(visibleBounds)
+
       val content =
         ContainerLikeFunctions
           .present(
-            ctx.withParentBounds(ctx.parent.bounds.moveBy(scrollOffset)),
+            contentCtx,
             model.dimensions,
             Batch(model.content)
           )
+
+      // This context is used for scrollbars , which only ever care about the visible space
+      val scrollbarBounds = visibleBounds
+      val ctx             = context.withParentBounds(scrollbarBounds).pushInputClip(scrollbarBounds)
 
       val layers: Outcome[Layer.Stack] =
         if scrollingActive then

--- a/indigo-extras/src/indigoextras/ui/components/ScrollPane.scala
+++ b/indigo-extras/src/indigoextras/ui/components/ScrollPane.scala
@@ -238,7 +238,7 @@ object ScrollPane:
               model.copy(content = updatedContent)
             }
 
-          case WheelEvent.Vertical(deltaY) if model.scrollOptions.isEnabled && ctx.pointerIsWithinInputClip =>
+          case WheelEvent.Vertical(deltaY) if model.scrollOptions.isEnabled && ctx.pointerIsWithinActiveInputBounds =>
             val scrollBy =
               val speed =
                 if model.dimensions.height > 0 then model.dimensions.height / 10 else 1
@@ -306,13 +306,7 @@ object ScrollPane:
               scrollBar = updatedScrollBar
             )
 
-    override def hitTest(
-        context: UIContext[ReferenceData],
-        model: ScrollPane[A, ReferenceData]
-    ): Boolean =
-      hitTest(context, model, PointerEvent.Move(context.pointerCoords.unsafeToPoint))
-
-    override def hitTest(
+    def hitTest(
         context: UIContext[ReferenceData],
         model: ScrollPane[A, ReferenceData],
         event: GlobalEvent
@@ -336,12 +330,12 @@ object ScrollPane:
 
       event match
         case _: WheelEvent =>
-          contentHit || (model.scrollOptions.isEnabled && ctx.pointerIsWithinInputClip)
+          contentHit || (model.scrollOptions.isEnabled && ctx.pointerIsWithinActiveInputBounds)
 
         case _ =>
           scrollBarHit || contentHit
 
-    override def hasPointerCapture(
+    def hasPointerCapture(
         context: UIContext[ReferenceData],
         model: ScrollPane[A, ReferenceData]
     ): Boolean =
@@ -580,7 +574,7 @@ object ScrollPane:
 
       context
         .withParentBounds(bounds)
-        .pushInputClip(bounds)
+        .pushActiveInputBounds(bounds)
 
     private def scrolledContentContext(
         context: UIContext[ReferenceData],

--- a/indigo-extras/src/indigoextras/ui/components/ScrollPane.scala
+++ b/indigo-extras/src/indigoextras/ui/components/ScrollPane.scala
@@ -341,6 +341,25 @@ object ScrollPane:
         case _ =>
           scrollBarHit || contentHit
 
+    override def hasPointerCapture(
+        context: UIContext[ReferenceData],
+        model: ScrollPane[A, ReferenceData]
+    ): Boolean =
+      val scrollingActive =
+        model.scrollOptions.isEnabled && model.contentBounds.height > model.dimensions.height
+
+      val ctx        = viewportContext(context, model)
+      val contentCtx = scrolledContentContext(ctx, model, scrollingActive)
+      val scrollCtx  = scrollBarInputContext(ctx, model)
+
+      val scrollBarCaptured =
+        scrollingActive && summon[Component[Button[Unit], Unit]].hasPointerCapture(scrollCtx, model.scrollBar)
+
+      val contentCaptured =
+        model.content.component.hasPointerCapture(contentCtx, model.content.model)
+
+      scrollBarCaptured || contentCaptured
+
     def present(
         context: UIContext[ReferenceData],
         model: ScrollPane[A, ReferenceData]

--- a/indigo-extras/src/indigoextras/ui/components/ScrollPane.scala
+++ b/indigo-extras/src/indigoextras/ui/components/ScrollPane.scala
@@ -306,7 +306,7 @@ object ScrollPane:
               scrollBar = updatedScrollBar
             )
 
-    def hitTest(
+    override def hitTest(
         context: UIContext[ReferenceData],
         model: ScrollPane[A, ReferenceData],
         event: GlobalEvent
@@ -335,7 +335,7 @@ object ScrollPane:
         case _ =>
           scrollBarHit || contentHit
 
-    def hasPointerCapture(
+    override def hasPointerCapture(
         context: UIContext[ReferenceData],
         model: ScrollPane[A, ReferenceData]
     ): Boolean =

--- a/indigo-extras/src/indigoextras/ui/components/ScrollPane.scala
+++ b/indigo-extras/src/indigoextras/ui/components/ScrollPane.scala
@@ -199,65 +199,18 @@ object ScrollPane:
         val scrollingActive =
           model.scrollOptions.isEnabled && model.contentBounds.height > model.dimensions.height
 
-        val scrollOffset: Coords =
-          if scrollingActive then
-            Coords(
-              0,
-              ((model.dimensions.height.toDouble - model.contentBounds.height.toDouble) * model.scrollAmount).toInt
-            )
-          else Coords.zero
-
-        val visibleBounds  = Bounds(context.parent.coords, model.dimensions)
-        val scrolledBounds = visibleBounds.moveBy(scrollOffset)
-        val ctx            = context.withParentBounds(visibleBounds).pushInputClip(visibleBounds)
-        val contentCtx     = ctx.withParentBounds(scrolledBounds)
+        val ctx        = viewportContext(context, model)
+        val contentCtx = scrolledContentContext(ctx, model, scrollingActive)
+        val scrollCtx  = scrollBarInputContext(ctx, model)
 
         def updateScrollBar: Outcome[Button[Unit]] =
           val c: Component[Button[Unit], Unit] = summon[Component[Button[Unit], Unit]]
-          val unitContext: UIContext[Unit] =
-            ctx
-              .copy(reference = ())
-              .withParent(
-                ctx.parent
-                  .moveBy(
-                    Coords(
-                      model.dimensions.width - model.scrollBar.bounds.width,
-                      0
-                    )
-                  )
-                  .withAdditionalOffset(
-                    Coords(
-                      0,
-                      ((model.dimensions.height - model.scrollBar.bounds.height).toDouble * model.scrollAmount).toInt
-                    )
-                  )
-              )
-
-          c.updateModel(unitContext, model.scrollBar)(e)
+          c.updateModel(scrollCtx, model.scrollBar)(e)
 
         def updateScrollBarWith(events: Batch[GlobalEvent]): Outcome[Button[Unit]] =
           val c: Component[Button[Unit], Unit] = summon[Component[Button[Unit], Unit]]
-          val unitContext: UIContext[Unit] =
-            ctx
-              .copy(reference = ())
-              .withParent(
-                ctx.parent
-                  .moveBy(
-                    Coords(
-                      model.dimensions.width - model.scrollBar.bounds.width,
-                      0
-                    )
-                  )
-                  .withAdditionalOffset(
-                    Coords(
-                      0,
-                      ((model.dimensions.height - model.scrollBar.bounds.height).toDouble * model.scrollAmount).toInt
-                    )
-                  )
-              )
-
           events.foldLeft(Outcome(model.scrollBar)) { (acc, event) =>
-            acc.flatMap(c.updateModel(unitContext, _)(event))
+            acc.flatMap(c.updateModel(scrollCtx, _)(event))
           }
 
         def routeContent(event: GlobalEvent): Outcome[ComponentEntry[A, ReferenceData]] =
@@ -274,23 +227,7 @@ object ScrollPane:
 
         def scrollBarHit(event: GlobalEvent): Boolean =
           scrollingActive && summon[Component[Button[Unit], Unit]].hitTest(
-            ctx
-              .copy(reference = ())
-              .withParent(
-                ctx.parent
-                  .moveBy(
-                    Coords(
-                      model.dimensions.width - model.scrollBar.bounds.width,
-                      0
-                    )
-                  )
-                  .withAdditionalOffset(
-                    Coords(
-                      0,
-                      ((model.dimensions.height - model.scrollBar.bounds.height).toDouble * model.scrollAmount).toInt
-                    )
-                  )
-              ),
+            scrollCtx,
             model.scrollBar,
             event
           )
@@ -303,7 +240,7 @@ object ScrollPane:
             }
 
           case WheelEvent.Vertical(deltaY)
-              if model.scrollOptions.isEnabled && visibleBounds.contains(context.pointerCoords) =>
+              if model.scrollOptions.isEnabled && ctx.pointerIsWithinInputClip =>
             val scrollBy =
               val speed =
                 if model.dimensions.height > 0 then model.dimensions.height / 10 else 1
@@ -385,38 +322,13 @@ object ScrollPane:
       val scrollingActive =
         model.scrollOptions.isEnabled && model.contentBounds.height > model.dimensions.height
 
-      val scrollOffset: Coords =
-        if scrollingActive then
-          Coords(
-            0,
-            ((model.dimensions.height.toDouble - model.contentBounds.height.toDouble) * model.scrollAmount).toInt
-          )
-        else Coords.zero
-
-      val visibleBounds  = Bounds(context.parent.coords, model.dimensions)
-      val scrolledBounds = visibleBounds.moveBy(scrollOffset)
-      val ctx            = context.withParentBounds(visibleBounds).pushInputClip(visibleBounds)
-      val contentCtx     = ctx.withParentBounds(scrolledBounds)
+      val ctx        = viewportContext(context, model)
+      val contentCtx = scrolledContentContext(ctx, model, scrollingActive)
+      val scrollCtx  = scrollBarInputContext(ctx, model)
 
       val scrollBarHit =
         scrollingActive && summon[Component[Button[Unit], Unit]].hitTest(
-          ctx
-            .copy(reference = ())
-            .withParent(
-              ctx.parent
-                .moveBy(
-                  Coords(
-                    model.dimensions.width - model.scrollBar.bounds.width,
-                    0
-                  )
-                )
-                .withAdditionalOffset(
-                  Coords(
-                    0,
-                    ((model.dimensions.height - model.scrollBar.bounds.height).toDouble * model.scrollAmount).toInt
-                  )
-                )
-            ),
+          scrollCtx,
           model.scrollBar,
           event
         )
@@ -426,7 +338,7 @@ object ScrollPane:
 
       event match
         case _: WheelEvent =>
-          contentHit || (model.scrollOptions.isEnabled && visibleBounds.contains(context.pointerCoords))
+          contentHit || (model.scrollOptions.isEnabled && ctx.pointerIsWithinInputClip)
 
         case _ =>
           scrollBarHit || contentHit
@@ -438,18 +350,8 @@ object ScrollPane:
       val scrollingActive =
         model.scrollOptions.isEnabled && model.contentBounds.height > model.dimensions.height
 
-      val scrollOffset: Coords =
-        if scrollingActive then
-          Coords(
-            0,
-            ((model.dimensions.height.toDouble - model.contentBounds.height.toDouble) * model.scrollAmount).toInt
-          )
-        else Coords.zero
-
-      val visibleBounds  = Bounds(context.parent.coords, model.dimensions)
-      val scrolledBounds = visibleBounds.moveBy(scrollOffset)
-      val contentCtx     =
-        context.withParentBounds(scrolledBounds).pushInputClip(visibleBounds)
+      val ctx        = viewportContext(context, model)
+      val contentCtx = scrolledContentContext(ctx, model, scrollingActive)
 
       val content =
         ContainerLikeFunctions
@@ -459,25 +361,13 @@ object ScrollPane:
             Batch(model.content)
           )
 
-      // This context is used for scrollbars , which only ever care about the visible space
-      val scrollbarBounds = visibleBounds
-      val ctx             = context.withParentBounds(scrollbarBounds).pushInputClip(scrollbarBounds)
-
       val layers: Outcome[Layer.Stack] =
         if scrollingActive then
           val c: Component[Button[Unit], Unit] = summon[Component[Button[Unit], Unit]]
-          val unitContext: UIContext[Unit]     = ctx.copy(reference = ())
+          val unitContext: UIContext[Unit]     = scrollBarPresentContext(ctx, model)
           val scrollbar =
             c.present(
-              unitContext
-                .withParentBounds(
-                  unitContext.parent.bounds.moveBy(
-                    Coords(
-                      model.dimensions.width - model.scrollBar.bounds.width,
-                      ((model.dimensions.height - model.scrollBar.bounds.height).toDouble * model.scrollAmount).toInt
-                    )
-                  )
-                ),
+              unitContext,
               model.scrollBar
             )
           val scrollBg =
@@ -653,6 +543,73 @@ object ScrollPane:
         content = updatedComponent,
         scrollBar = model.scrollBar.fixedDragArea(dragArea)
       )
+
+    private def scrollOffset(model: ScrollPane[A, ReferenceData], scrollingActive: Boolean): Coords =
+      if scrollingActive then
+        Coords(
+          0,
+          ((model.dimensions.height.toDouble - model.contentBounds.height.toDouble) * model.scrollAmount).toInt
+        )
+      else Coords.zero
+
+    private def viewportBounds(context: UIContext[ReferenceData], model: ScrollPane[A, ReferenceData]): Bounds =
+      Bounds(context.parent.coords, model.dimensions)
+
+    private def viewportContext(
+        context: UIContext[ReferenceData],
+        model: ScrollPane[A, ReferenceData]
+    ): UIContext[ReferenceData] =
+      val bounds = viewportBounds(context, model)
+
+      context
+        .withParentBounds(bounds)
+        .pushInputClip(bounds)
+
+    private def scrolledContentContext(
+        context: UIContext[ReferenceData],
+        model: ScrollPane[A, ReferenceData],
+        scrollingActive: Boolean
+    ): UIContext[ReferenceData] =
+      context.withParentBounds(
+        context.parent.bounds.moveBy(scrollOffset(model, scrollingActive))
+      )
+
+    private def scrollBarInputContext(
+        context: UIContext[ReferenceData],
+        model: ScrollPane[A, ReferenceData]
+    ): UIContext[Unit] =
+      context
+        .copy(reference = ())
+        .withParent(
+          context.parent
+            .moveBy(
+              Coords(
+                model.dimensions.width - model.scrollBar.bounds.width,
+                0
+              )
+            )
+            .withAdditionalOffset(
+              Coords(
+                0,
+                ((model.dimensions.height - model.scrollBar.bounds.height).toDouble * model.scrollAmount).toInt
+              )
+            )
+        )
+
+    private def scrollBarPresentContext(
+        context: UIContext[ReferenceData],
+        model: ScrollPane[A, ReferenceData]
+    ): UIContext[Unit] =
+      context
+        .copy(reference = ())
+        .withParentBounds(
+          context.parent.bounds.moveBy(
+            Coords(
+              model.dimensions.width - model.scrollBar.bounds.width,
+              ((model.dimensions.height - model.scrollBar.bounds.height).toDouble * model.scrollAmount).toInt
+            )
+          )
+        )
 
 enum ScrollPaneEvent extends GlobalEvent:
   case Scroll(bindingKey: BindingKey, amount: Int)

--- a/indigo-extras/src/indigoextras/ui/components/Switch.scala
+++ b/indigo-extras/src/indigoextras/ui/components/Switch.scala
@@ -161,6 +161,9 @@ object Switch:
         case _: WheelEvent => false
         case _             => hitTest(context, model)
 
+    override def hasPointerCapture(context: UIContext[ReferenceData], model: Switch[ReferenceData]): Boolean =
+      model.isDown
+
     def present(
         context: UIContext[ReferenceData],
         model: Switch[ReferenceData]

--- a/indigo-extras/src/indigoextras/ui/components/Switch.scala
+++ b/indigo-extras/src/indigoextras/ui/components/Switch.scala
@@ -153,15 +153,12 @@ object Switch:
       case _ =>
         Outcome(model)
 
-    override def hitTest(context: UIContext[ReferenceData], model: Switch[ReferenceData]): Boolean =
-      coordsInBounds(context.pointerCoords, model.bounds, context)
-
-    override def hitTest(context: UIContext[ReferenceData], model: Switch[ReferenceData], event: GlobalEvent): Boolean =
+    def hitTest(context: UIContext[ReferenceData], model: Switch[ReferenceData], event: GlobalEvent): Boolean =
       event match
         case _: WheelEvent => false
-        case _             => hitTest(context, model)
+        case _             => coordsInBounds(context.pointerCoords, model.bounds, context)
 
-    override def hasPointerCapture(context: UIContext[ReferenceData], model: Switch[ReferenceData]): Boolean =
+    def hasPointerCapture(context: UIContext[ReferenceData], model: Switch[ReferenceData]): Boolean =
       model.isDown
 
     def present(
@@ -213,7 +210,7 @@ object Switch:
           )
 
   private def coordsInBounds[ReferenceData](pnt: Coords, bounds: Bounds, context: UIContext[ReferenceData]): Boolean =
-    context.pointerIsWithinInputClip &&
+    context.pointerIsWithinActiveInputBounds &&
       bounds
         .moveBy(context.parent.coords + context.parent.additionalOffset)
         .contains(pnt)

--- a/indigo-extras/src/indigoextras/ui/components/Switch.scala
+++ b/indigo-extras/src/indigoextras/ui/components/Switch.scala
@@ -136,8 +136,7 @@ object Switch:
           )
         )
 
-      case _: PointerEvent.Down
-          if context.isActive && coordsInBounds(context.pointerCoords, model.bounds, context) =>
+      case _: PointerEvent.Down if context.isActive && coordsInBounds(context.pointerCoords, model.bounds, context) =>
         Outcome(model.copy(isDown = true))
 
       case _: PointerEvent.Up

--- a/indigo-extras/src/indigoextras/ui/components/Switch.scala
+++ b/indigo-extras/src/indigoextras/ui/components/Switch.scala
@@ -3,7 +3,6 @@ package indigoextras.ui.components
 import indigo.*
 import indigoextras.ui.component.Component
 import indigoextras.ui.datatypes.Bounds
-import indigoextras.ui.datatypes.Coords
 import indigoextras.ui.datatypes.UIContext
 
 import datatypes.BoundsType
@@ -136,11 +135,11 @@ object Switch:
           )
         )
 
-      case _: PointerEvent.Down if context.isActive && coordsInBounds(context.pointerCoords, model.bounds, context) =>
+      case _: PointerEvent.Down if context.isActive && coordsInBounds(context.pointerCoords, context, model) =>
         Outcome(model.copy(isDown = true))
 
       case _: PointerEvent.Up
-          if context.isActive && model.isDown && coordsInBounds(context.pointerCoords, model.bounds, context) =>
+          if context.isActive && model.isDown && coordsInBounds(context.pointerCoords, context, model) =>
         val next    = model.state.toggle
         val updated = model.copy(state = next, isDown = false)
         Outcome(updated)
@@ -153,12 +152,7 @@ object Switch:
       case _ =>
         Outcome(model)
 
-    def hitTest(context: UIContext[ReferenceData], model: Switch[ReferenceData], event: GlobalEvent): Boolean =
-      event match
-        case _: WheelEvent => false
-        case _             => coordsInBounds(context.pointerCoords, model.bounds, context)
-
-    def hasPointerCapture(context: UIContext[ReferenceData], model: Switch[ReferenceData]): Boolean =
+    override def hasPointerCapture(context: UIContext[ReferenceData], model: Switch[ReferenceData]): Boolean =
       model.isDown
 
     def present(
@@ -208,9 +202,3 @@ object Switch:
               context.parent.bounds.height - padding.top - padding.bottom
             )
           )
-
-  private def coordsInBounds[ReferenceData](pnt: Coords, bounds: Bounds, context: UIContext[ReferenceData]): Boolean =
-    context.pointerIsWithinActiveInputBounds &&
-      bounds
-        .moveBy(context.parent.coords + context.parent.additionalOffset)
-        .contains(pnt)

--- a/indigo-extras/src/indigoextras/ui/components/Switch.scala
+++ b/indigo-extras/src/indigoextras/ui/components/Switch.scala
@@ -3,8 +3,8 @@ package indigoextras.ui.components
 import indigo.*
 import indigoextras.ui.component.Component
 import indigoextras.ui.datatypes.Bounds
-import indigoextras.ui.datatypes.UIContext
 import indigoextras.ui.datatypes.Coords
+import indigoextras.ui.datatypes.UIContext
 
 import datatypes.BoundsType
 import datatypes.SwitchState

--- a/indigo-extras/src/indigoextras/ui/components/Switch.scala
+++ b/indigo-extras/src/indigoextras/ui/components/Switch.scala
@@ -4,6 +4,7 @@ import indigo.*
 import indigoextras.ui.component.Component
 import indigoextras.ui.datatypes.Bounds
 import indigoextras.ui.datatypes.UIContext
+import indigoextras.ui.datatypes.Coords
 
 import datatypes.BoundsType
 import datatypes.SwitchState
@@ -136,15 +137,11 @@ object Switch:
         )
 
       case _: PointerEvent.Down
-          if context.isActive && model.bounds
-            .moveBy(context.parent.coords + context.parent.additionalOffset)
-            .contains(context.pointerCoords) =>
+          if context.isActive && coordsInBounds(context.pointerCoords, model.bounds, context) =>
         Outcome(model.copy(isDown = true))
 
       case _: PointerEvent.Up
-          if context.isActive && model.isDown && model.bounds
-            .moveBy(context.parent.coords + context.parent.additionalOffset)
-            .contains(context.pointerCoords) =>
+          if context.isActive && model.isDown && coordsInBounds(context.pointerCoords, model.bounds, context) =>
         val next    = model.state.toggle
         val updated = model.copy(state = next, isDown = false)
         Outcome(updated)
@@ -156,6 +153,14 @@ object Switch:
 
       case _ =>
         Outcome(model)
+
+    override def hitTest(context: UIContext[ReferenceData], model: Switch[ReferenceData]): Boolean =
+      coordsInBounds(context.pointerCoords, model.bounds, context)
+
+    override def hitTest(context: UIContext[ReferenceData], model: Switch[ReferenceData], event: GlobalEvent): Boolean =
+      event match
+        case _: WheelEvent => false
+        case _             => hitTest(context, model)
 
     def present(
         context: UIContext[ReferenceData],
@@ -204,3 +209,9 @@ object Switch:
               context.parent.bounds.height - padding.top - padding.bottom
             )
           )
+
+  private def coordsInBounds[ReferenceData](pnt: Coords, bounds: Bounds, context: UIContext[ReferenceData]): Boolean =
+    context.pointerIsWithinInputClip &&
+      bounds
+        .moveBy(context.parent.coords + context.parent.additionalOffset)
+        .contains(pnt)

--- a/indigo-extras/src/indigoextras/ui/components/TextArea.scala
+++ b/indigo-extras/src/indigoextras/ui/components/TextArea.scala
@@ -6,6 +6,7 @@ import indigoextras.ui.datatypes.Bounds
 import indigoextras.ui.datatypes.UIContext
 
 import scala.annotation.targetName
+import indigoextras.ui.datatypes.Coords
 
 /** `TextArea`s are a simple stateless component that render multi-line text.
   */
@@ -89,3 +90,21 @@ object TextArea:
         model: TextArea[ReferenceData]
     ): TextArea[ReferenceData] =
       model
+
+    def hitTest(
+        context: UIContext[ReferenceData],
+        model: TextArea[ReferenceData],
+        event: GlobalEvent
+    ): Boolean =
+      event match
+        case _: WheelEvent => false
+        case _ => coordsInBounds(context.pointerCoords, model.calculateBounds(context, model.text(context)), context)
+
+    def hasPointerCapture(context: UIContext[ReferenceData], model: TextArea[ReferenceData]): Boolean =
+      false
+
+  private def coordsInBounds[ReferenceData](pnt: Coords, bounds: Bounds, context: UIContext[ReferenceData]): Boolean =
+    context.pointerIsWithinActiveInputBounds &&
+      bounds
+        .moveBy(context.parent.coords + context.parent.additionalOffset)
+        .contains(pnt)

--- a/indigo-extras/src/indigoextras/ui/components/TextArea.scala
+++ b/indigo-extras/src/indigoextras/ui/components/TextArea.scala
@@ -6,7 +6,6 @@ import indigoextras.ui.datatypes.Bounds
 import indigoextras.ui.datatypes.UIContext
 
 import scala.annotation.targetName
-import indigoextras.ui.datatypes.Coords
 
 /** `TextArea`s are a simple stateless component that render multi-line text.
   */
@@ -91,20 +90,8 @@ object TextArea:
     ): TextArea[ReferenceData] =
       model
 
-    def hitTest(
+    override def hitTest(
         context: UIContext[ReferenceData],
         model: TextArea[ReferenceData],
         event: GlobalEvent
-    ): Boolean =
-      event match
-        case _: WheelEvent => false
-        case _ => coordsInBounds(context.pointerCoords, model.calculateBounds(context, model.text(context)), context)
-
-    def hasPointerCapture(context: UIContext[ReferenceData], model: TextArea[ReferenceData]): Boolean =
-      false
-
-  private def coordsInBounds[ReferenceData](pnt: Coords, bounds: Bounds, context: UIContext[ReferenceData]): Boolean =
-    context.pointerIsWithinActiveInputBounds &&
-      bounds
-        .moveBy(context.parent.coords + context.parent.additionalOffset)
-        .contains(pnt)
+    ): Boolean = false

--- a/indigo-extras/src/indigoextras/ui/components/datatypes/ContainerLikeFunctions.scala
+++ b/indigo-extras/src/indigoextras/ui/components/datatypes/ContainerLikeFunctions.scala
@@ -68,23 +68,17 @@ object ContainerLikeFunctions:
 
   def hitTest[ReferenceData](
       context: UIContext[ReferenceData],
-      dimensions: Dimensions,
       components: Batch[ComponentEntry[?, ReferenceData]]
   ): Boolean =
-    val _ = dimensions
-
     components.exists { c =>
       c.component.hitTest(routedChildContext(context, c), c.model)
     }
 
   def hitTest[ReferenceData](
       context: UIContext[ReferenceData],
-      dimensions: Dimensions,
       components: Batch[ComponentEntry[?, ReferenceData]],
       event: GlobalEvent
   ): Boolean =
-    val _ = dimensions
-
     components.exists { c =>
       c.component.hitTest(routedChildContext(context, c), c.model, event)
     }
@@ -95,7 +89,7 @@ object ContainerLikeFunctions:
       components: Batch[ComponentEntry[?, ReferenceData]]
   ): GlobalEvent => Outcome[Batch[ComponentEntry[?, ReferenceData]]] =
     case event if PointerRouting.isRoutedEvent(event) =>
-      route(context, dimensions, components, event)
+      route(context, components, event)
 
     case event =>
       components
@@ -106,12 +100,9 @@ object ContainerLikeFunctions:
 
   private def route[ReferenceData](
       context: UIContext[ReferenceData],
-      dimensions: Dimensions,
       components: Batch[ComponentEntry[?, ReferenceData]],
       event: GlobalEvent
   ): Outcome[Batch[ComponentEntry[?, ReferenceData]]] =
-    val _ = dimensions
-
     val entries = components.toList
 
     val maybeTargetIndex =
@@ -138,7 +129,7 @@ object ContainerLikeFunctions:
         Batch(PointerRouting.enterFrom(move), move)
 
       case move: PointerEvent.Move =>
-        Batch(PointerRouting.leaveFrom(move), move)
+        Batch(PointerRouting.leaveFrom(move))
 
       case _: PointerEvent.Up | _: PointerEvent.Cancel | _: PointerEvent.Leave =>
         Batch(event)

--- a/indigo-extras/src/indigoextras/ui/components/datatypes/ContainerLikeFunctions.scala
+++ b/indigo-extras/src/indigoextras/ui/components/datatypes/ContainerLikeFunctions.scala
@@ -83,6 +83,14 @@ object ContainerLikeFunctions:
       c.component.hitTest(routedChildContext(context, c), c.model, event)
     }
 
+  def hasPointerCapture[ReferenceData](
+      context: UIContext[ReferenceData],
+      components: Batch[ComponentEntry[?, ReferenceData]]
+  ): Boolean =
+    components.exists { c =>
+      c.component.hasPointerCapture(routedChildContext(context, c), c.model)
+    }
+
   def routeOrBroadcast[ReferenceData](
       context: UIContext[ReferenceData],
       dimensions: Dimensions,
@@ -104,12 +112,29 @@ object ContainerLikeFunctions:
   ): Outcome[Batch[ComponentEntry[?, ReferenceData]]] =
     val entries = components.toList
 
-    val maybeTargetIndex =
+    val indexedEntries =
       entries.zipWithIndex.reverse
-        .find { case (entry, _) =>
-          entry.component.hitTest(routedChildContext(context, entry), entry.model, event)
-        }
-        .map(_._2)
+
+    val maybeCapturedIndex =
+      event match
+        case _: PointerEvent =>
+          indexedEntries
+            .find { case (entry, _) =>
+              entry.component.hasPointerCapture(routedChildContext(context, entry), entry.model)
+            }
+            .map(_._2)
+
+        case _ =>
+          None
+
+    val maybeTargetIndex =
+      maybeCapturedIndex.orElse(
+        indexedEntries
+          .find { case (entry, _) =>
+            entry.component.hitTest(routedChildContext(context, entry), entry.model, event)
+          }
+          .map(_._2)
+      )
 
     Batch
       .fromSeq(entries.zipWithIndex)

--- a/indigo-extras/src/indigoextras/ui/components/datatypes/ContainerLikeFunctions.scala
+++ b/indigo-extras/src/indigoextras/ui/components/datatypes/ContainerLikeFunctions.scala
@@ -92,11 +92,9 @@ object ContainerLikeFunctions:
       route(context, components, event)
 
     case event =>
-      components
-        .map { c =>
-          updateEntry(childContext(context, dimensions, c), c, Batch(event))
-        }
-        .sequence
+      components.map { c =>
+        updateEntry(childContext(context, dimensions, c), c, Batch(event))
+      }.sequence
 
   private def route[ReferenceData](
       context: UIContext[ReferenceData],

--- a/indigo-extras/src/indigoextras/ui/components/datatypes/ContainerLikeFunctions.scala
+++ b/indigo-extras/src/indigoextras/ui/components/datatypes/ContainerLikeFunctions.scala
@@ -68,14 +68,6 @@ object ContainerLikeFunctions:
 
   def hitTest[ReferenceData](
       context: UIContext[ReferenceData],
-      components: Batch[ComponentEntry[?, ReferenceData]]
-  ): Boolean =
-    components.exists { c =>
-      c.component.hitTest(routedChildContext(context, c), c.model)
-    }
-
-  def hitTest[ReferenceData](
-      context: UIContext[ReferenceData],
       components: Batch[ComponentEntry[?, ReferenceData]],
       event: GlobalEvent
   ): Boolean =

--- a/indigo-extras/src/indigoextras/ui/components/datatypes/ContainerLikeFunctions.scala
+++ b/indigo-extras/src/indigoextras/ui/components/datatypes/ContainerLikeFunctions.scala
@@ -89,7 +89,7 @@ object ContainerLikeFunctions:
       components: Batch[ComponentEntry[?, ReferenceData]]
   ): GlobalEvent => Outcome[Batch[ComponentEntry[?, ReferenceData]]] =
     case event if PointerRouting.isRoutedEvent(event) =>
-      route(context, components, event)
+      route(context, dimensions, components, event)
 
     case event =>
       components.map { c =>
@@ -98,6 +98,7 @@ object ContainerLikeFunctions:
 
   private def route[ReferenceData](
       context: UIContext[ReferenceData],
+      dimensions: Dimensions,
       components: Batch[ComponentEntry[?, ReferenceData]],
       event: GlobalEvent
   ): Outcome[Batch[ComponentEntry[?, ReferenceData]]] =
@@ -117,7 +118,7 @@ object ContainerLikeFunctions:
           routedEvents(event, maybeTargetIndex.contains(index))
 
         if events.isEmpty then Outcome(entry)
-        else updateEntry(routedChildContext(context, entry), entry, events)
+        else updateEntry(childContext(context, dimensions, entry), entry, events)
       }
       .sequence
 

--- a/indigo-extras/src/indigoextras/ui/components/datatypes/ContainerLikeFunctions.scala
+++ b/indigo-extras/src/indigoextras/ui/components/datatypes/ContainerLikeFunctions.scala
@@ -4,6 +4,7 @@ import indigo.*
 import indigoextras.ui.datatypes.Bounds
 import indigoextras.ui.datatypes.Coords
 import indigoextras.ui.datatypes.Dimensions
+import indigoextras.ui.datatypes.PointerRouting
 import indigoextras.ui.datatypes.UIContext
 
 object ContainerLikeFunctions:
@@ -64,3 +65,120 @@ object ContainerLikeFunctions:
       }
       .sequence
       .map(_.foldLeft(Layer.Stack.empty)(_ :+ _))
+
+  def hitTest[ReferenceData](
+      context: UIContext[ReferenceData],
+      dimensions: Dimensions,
+      components: Batch[ComponentEntry[?, ReferenceData]]
+  ): Boolean =
+    val _ = dimensions
+
+    components.exists { c =>
+      c.component.hitTest(routedChildContext(context, c), c.model)
+    }
+
+  def hitTest[ReferenceData](
+      context: UIContext[ReferenceData],
+      dimensions: Dimensions,
+      components: Batch[ComponentEntry[?, ReferenceData]],
+      event: GlobalEvent
+  ): Boolean =
+    val _ = dimensions
+
+    components.exists { c =>
+      c.component.hitTest(routedChildContext(context, c), c.model, event)
+    }
+
+  def routeOrBroadcast[ReferenceData](
+      context: UIContext[ReferenceData],
+      dimensions: Dimensions,
+      components: Batch[ComponentEntry[?, ReferenceData]]
+  ): GlobalEvent => Outcome[Batch[ComponentEntry[?, ReferenceData]]] =
+    case event if PointerRouting.isRoutedEvent(event) =>
+      route(context, dimensions, components, event)
+
+    case event =>
+      components
+        .map { c =>
+          updateEntry(childContext(context, dimensions, c), c, Batch(event))
+        }
+        .sequence
+
+  private def route[ReferenceData](
+      context: UIContext[ReferenceData],
+      dimensions: Dimensions,
+      components: Batch[ComponentEntry[?, ReferenceData]],
+      event: GlobalEvent
+  ): Outcome[Batch[ComponentEntry[?, ReferenceData]]] =
+    val _ = dimensions
+
+    val entries = components.toList
+
+    val maybeTargetIndex =
+      entries.zipWithIndex.reverse
+        .find { case (entry, _) =>
+          entry.component.hitTest(routedChildContext(context, entry), entry.model, event)
+        }
+        .map(_._2)
+
+    Batch
+      .fromSeq(entries.zipWithIndex)
+      .map { case (entry, index) =>
+        val events =
+          routedEvents(event, maybeTargetIndex.contains(index))
+
+        if events.isEmpty then Outcome(entry)
+        else updateEntry(routedChildContext(context, entry), entry, events)
+      }
+      .sequence
+
+  private def routedEvents(event: GlobalEvent, isTarget: Boolean): Batch[GlobalEvent] =
+    event match
+      case move: PointerEvent.Move if isTarget =>
+        Batch(PointerRouting.enterFrom(move), move)
+
+      case move: PointerEvent.Move =>
+        Batch(PointerRouting.leaveFrom(move), move)
+
+      case _: PointerEvent.Up | _: PointerEvent.Cancel | _: PointerEvent.Leave =>
+        Batch(event)
+
+      case _: PointerEvent if isTarget =>
+        Batch(event)
+
+      case _: WheelEvent if isTarget =>
+        Batch(event)
+
+      case _ =>
+        Batch.empty
+
+  private def updateEntry[A, ReferenceData](
+      context: UIContext[ReferenceData],
+      entry: ComponentEntry[A, ReferenceData],
+      events: Batch[GlobalEvent]
+  ): Outcome[ComponentEntry[A, ReferenceData]] =
+    events
+      .foldLeft(Outcome(entry.model)) { (acc, event) =>
+        acc.flatMap(entry.component.updateModel(context, _)(event))
+      }
+      .map(updated => entry.copy(model = updated))
+
+  private def childContext[ReferenceData](
+      context: UIContext[ReferenceData],
+      dimensions: Dimensions,
+      component: ComponentEntry[?, ReferenceData]
+  ): UIContext[ReferenceData] =
+    context.withParentBounds(Bounds(context.parent.bounds.moveBy(component.offset).coords, dimensions))
+
+  private def routedChildContext[ReferenceData](
+      context: UIContext[ReferenceData],
+      component: ComponentEntry[?, ReferenceData]
+  ): UIContext[ReferenceData] =
+    val bounds = component.component.bounds(context, component.model)
+
+    context.withParentBounds(
+      Bounds(
+        context.parent.bounds.moveBy(component.offset).coords,
+        bounds.dimensions
+      )
+    )

--- a/indigo-extras/src/indigoextras/ui/components/datatypes/ContainerLikeFunctions.scala
+++ b/indigo-extras/src/indigoextras/ui/components/datatypes/ContainerLikeFunctions.scala
@@ -96,6 +96,40 @@ object ContainerLikeFunctions:
         updateEntry(childContext(context, dimensions, c), c, Batch(event))
       }.sequence
 
+  /** Routing for containers that hold exactly one, statically typed, child. There is no target to select, so all that
+    * remains is to decide whether the child is the target, and to synthesise the enter/leave events that go with that.
+    */
+  def routeOne[A, ReferenceData](
+      context: UIContext[ReferenceData],
+      dimensions: Dimensions,
+      component: ComponentEntry[A, ReferenceData]
+  ): GlobalEvent => Outcome[ComponentEntry[A, ReferenceData]] =
+    case event if PointerRouting.isRoutedEvent(event) =>
+      val isTarget =
+        isCaptured(context, component, event) ||
+          component.component.hitTest(routedChildContext(context, component), component.model, event)
+
+      val events =
+        routedEvents(event, isTarget)
+
+      if events.isEmpty then Outcome(component)
+      else updateEntry(childContext(context, dimensions, component), component, events)
+
+    case event =>
+      updateEntry(childContext(context, dimensions, component), component, Batch(event))
+
+  private def isCaptured[ReferenceData](
+      context: UIContext[ReferenceData],
+      component: ComponentEntry[?, ReferenceData],
+      event: GlobalEvent
+  ): Boolean =
+    event match
+      case _: PointerEvent =>
+        component.component.hasPointerCapture(routedChildContext(context, component), component.model)
+
+      case _ =>
+        false
+
   private def route[ReferenceData](
       context: UIContext[ReferenceData],
       dimensions: Dimensions,
@@ -108,16 +142,9 @@ object ContainerLikeFunctions:
       entries.zipWithIndex.reverse
 
     val maybeCapturedIndex =
-      event match
-        case _: PointerEvent =>
-          indexedEntries
-            .find { case (entry, _) =>
-              entry.component.hasPointerCapture(routedChildContext(context, entry), entry.model)
-            }
-            .map(_._2)
-
-        case _ =>
-          None
+      indexedEntries
+        .find { case (entry, _) => isCaptured(context, entry, event) }
+        .map(_._2)
 
     val maybeTargetIndex =
       maybeCapturedIndex.orElse(

--- a/indigo-extras/src/indigoextras/ui/datatypes/PointerRouting.scala
+++ b/indigo-extras/src/indigoextras/ui/datatypes/PointerRouting.scala
@@ -1,0 +1,30 @@
+package indigoextras.ui.datatypes
+
+import indigo.*
+
+object PointerRouting:
+
+  def isRoutedEvent(event: GlobalEvent): Boolean =
+    event match
+      case _: PointerEvent => true
+      case _: WheelEvent   => true
+      case _               => false
+
+  def isPointerMove(event: GlobalEvent): Boolean =
+    event.isInstanceOf[PointerEvent.Move]
+
+  def enterFrom(move: PointerEvent.Move): PointerEvent.Enter =
+    PointerEvent.Enter(
+      pointerId = move.pointerId,
+      position = move.position,
+      movementPosition = move.movementPosition,
+      pointerType = move.pointerType
+    )
+
+  def leaveFrom(move: PointerEvent.Move): PointerEvent.Leave =
+    PointerEvent.Leave(
+      pointerId = move.pointerId,
+      position = move.position,
+      movementPosition = move.movementPosition,
+      pointerType = move.pointerType
+    )

--- a/indigo-extras/src/indigoextras/ui/datatypes/PointerRouting.scala
+++ b/indigo-extras/src/indigoextras/ui/datatypes/PointerRouting.scala
@@ -10,9 +10,6 @@ object PointerRouting:
       case _: WheelEvent   => true
       case _               => false
 
-  def isPointerMove(event: GlobalEvent): Boolean =
-    event.isInstanceOf[PointerEvent.Move]
-
   def enterFrom(move: PointerEvent.Move): PointerEvent.Enter =
     PointerEvent.Enter(
       pointerId = move.pointerId,

--- a/indigo-extras/src/indigoextras/ui/datatypes/UIContext.scala
+++ b/indigo-extras/src/indigoextras/ui/datatypes/UIContext.scala
@@ -13,7 +13,8 @@ final case class UIContext[ReferenceData](
     // The following are all the same as in SubSystemContext
     reference: ReferenceData,
     frame: Context.Frame,
-    services: Context.Services
+    services: Context.Services,
+    inputClip: Option[Bounds] = Option.empty
 ):
 
   lazy val isActive: Boolean =
@@ -27,6 +28,30 @@ final case class UIContext[ReferenceData](
 
   def withParentBounds(newBounds: Bounds): UIContext[ReferenceData] =
     withParent(parent.withBounds(newBounds))
+
+  def withInputClip(newClip: Bounds): UIContext[ReferenceData] =
+    this.copy(inputClip = Option(newClip))
+
+  def pushInputClip(newClip: Bounds): UIContext[ReferenceData] =
+    this.copy(inputClip = inputClip.map(intersect(_, newClip)).orElse(Option(newClip)))
+
+  def pointerIsWithinInputClip: Boolean =
+    inputClip.forall(_.contains(pointerCoords))
+
+  def pointerIsWithin(bounds: Bounds): Boolean =
+    pointerIsWithinInputClip &&
+      bounds
+        .moveBy(parent.coords + parent.additionalOffset)
+        .contains(pointerCoords)
+
+  private def intersect(a: Bounds, b: Bounds): Bounds =
+    val left   = math.max(a.left, b.left)
+    val top    = math.max(a.top, b.top)
+    val right  = math.min(a.right, b.right)
+    val bottom = math.min(a.bottom, b.bottom)
+
+    if right <= left || bottom <= top then Bounds.zero
+    else Bounds(left, top, right - left, bottom - top)
 
   def moveParentTo(newPosition: Coords): UIContext[ReferenceData] =
     withParent(parent.moveTo(newPosition))

--- a/indigo-extras/src/indigoextras/ui/datatypes/UIContext.scala
+++ b/indigo-extras/src/indigoextras/ui/datatypes/UIContext.scala
@@ -14,7 +14,7 @@ final case class UIContext[ReferenceData](
     reference: ReferenceData,
     frame: Context.Frame,
     services: Context.Services,
-    inputClip: Option[Bounds] = Option.empty
+    activeInputBounds: Option[Bounds] = Option.empty
 ):
 
   lazy val isActive: Boolean =
@@ -29,17 +29,17 @@ final case class UIContext[ReferenceData](
   def withParentBounds(newBounds: Bounds): UIContext[ReferenceData] =
     withParent(parent.withBounds(newBounds))
 
-  def withInputClip(newClip: Bounds): UIContext[ReferenceData] =
-    this.copy(inputClip = Option(newClip))
+  def withActiveInputBounds(newClip: Bounds): UIContext[ReferenceData] =
+    this.copy(activeInputBounds = Option(newClip))
 
-  def pushInputClip(newClip: Bounds): UIContext[ReferenceData] =
-    this.copy(inputClip = inputClip.map(intersect(_, newClip)).orElse(Option(newClip)))
+  def pushActiveInputBounds(newClip: Bounds): UIContext[ReferenceData] =
+    this.copy(activeInputBounds = activeInputBounds.map(intersect(_, newClip)).orElse(Option(newClip)))
 
-  def pointerIsWithinInputClip: Boolean =
-    inputClip.forall(_.contains(pointerCoords))
+  def pointerIsWithinActiveInputBounds: Boolean =
+    activeInputBounds.forall(_.contains(pointerCoords))
 
   def pointerIsWithin(bounds: Bounds): Boolean =
-    pointerIsWithinInputClip &&
+    pointerIsWithinActiveInputBounds &&
       bounds
         .moveBy(parent.coords + parent.additionalOffset)
         .contains(pointerCoords)


### PR DESCRIPTION
This new implementation now looks through the hit areas of component children and only re-routes pointer events to them if they pass a hit area test

Fixes #218 and #73
