### PR TITLE
FIXED #217: Prevent Compound Layer Magnification

### DIFF
--- a/indigo-core/src/indigo/core/events/InputEvent.scala
+++ b/indigo-core/src/indigo/core/events/InputEvent.scala
@@ -91,27 +91,27 @@ trait PositionalInputEvent extends InputEvent:
     */
   def pointerId: PointerId
 
-  /** Coordinates relative to the magnification level
+  /** Coordinates relative to the screen
     */
   def position: Point
 
-  /** The X position relative to the magnification level
+  /** The X position relative to the screen
     */
   def x: Int = position.x
 
-  /** The Y position relative to the magnification level
+  /** The Y position relative to the screen
     */
   def y: Int = position.y
 
-  /** The delta position between this event and the last event relative to the magnification level
+  /** The delta position between this event and the last event relative to the screen
     */
   def movementPosition: Point
 
-  /** The delta X position between this event and the last event relative to the magnification level
+  /** The delta X position between this event and the last event relative to the screen
     */
   def movementX: Int = movementPosition.x
 
-  /** The delta Y position between this event and the last event relative to the magnification level
+  /** The delta Y position between this event and the last event relative to the screen
     */
   def movementY: Int = movementPosition.y
 
@@ -122,11 +122,11 @@ sealed trait MouseEvent extends PositionalInputEvent:
     */
   def pointerId: PointerId
 
-  /** Coordinates relative to the magnification level
+  /** Coordinates relative to the screen
     */
   def position: Point
 
-  /** The delta position between this event and the last event relative to the magnification level
+  /** The delta position between this event and the last event relative to the screen
     */
   def movementPosition: Point
 
@@ -138,9 +138,9 @@ object MouseEvent:
     * @param pointerId
     *   The unique identifier for the pointer input
     * @param position
-    *   The position of the mouse pointer relative to the magnification level
+    *   The position of the mouse pointer relative to the screen
     * @param movementPosition
-    *   The delta position between this event and the last event relative to the magnification level
+    *   The delta position between this event and the last event relative to the screen
     * @param button
     *   The button that was clicked
     */
@@ -250,9 +250,9 @@ object MouseEvent:
     * @param pointerId
     *   The unique identifier for the pointer input
     * @param position
-    *   The position of the mouse pointer relative to the magnification level
+    *   The position of the mouse pointer relative to the screen
     * @param movementPosition
-    *   The delta position between this event and the last event relative to the magnification level
+    *   The delta position between this event and the last event relative to the screen
     * @param button
     *   The button that was released
     */
@@ -351,9 +351,9 @@ object MouseEvent:
     * @param pointerId
     *   The unique identifier for the pointer input
     * @param position
-    *   The position of the mouse pointer relative to the magnification level
+    *   The position of the mouse pointer relative to the screen
     * @param movementPosition
-    *   The delta position between this event and the last event relative to the magnification level
+    *   The delta position between this event and the last event relative to the screen
     * @param button
     *   The button that was pressed down
     */
@@ -393,9 +393,9 @@ object MouseEvent:
     * @param pointerId
     *   The unique identifier for the pointer input
     * @param position
-    *   The position of the mouse pointer relative to the magnification level
+    *   The position of the mouse pointer relative to the screen
     * @param movementPosition
-    *   The delta position between this event and the last event relative to the magnification level
+    *   The delta position between this event and the last event relative to the screen
     */
   final case class Move(
       pointerId: PointerId,
@@ -433,9 +433,9 @@ object MouseEvent:
     * @param pointerId
     *   The unique identifier for the pointer input
     * @param position
-    *   The position of the mouse pointer relative to the magnification level
+    *   The position of the mouse pointer relative to the screen
     * @param movementPosition
-    *   The delta position between this event and the last event relative to the magnification level
+    *   The delta position between this event and the last event relative to the screen
     */
   final case class Enter(
       pointerId: PointerId,
@@ -461,9 +461,9 @@ object MouseEvent:
     * @param pointerId
     *   The unique identifier for the pointer input
     * @param position
-    *   The position of the mouse pointer relative to the magnification level
+    *   The position of the mouse pointer relative to the screen
     * @param movementPosition
-    *   The delta position between this event and the last event relative to the magnification level
+    *   The delta position between this event and the last event relative to the screen
     */
   final case class Leave(
       pointerId: PointerId,
@@ -571,11 +571,11 @@ sealed trait TouchEvent extends PositionalInputEvent:
   /** The identifier of the finger that triggered the event */
   def fingerId: FingerId
 
-  /** Coordinates relative to the magnification level
+  /** Coordinates relative to the screen
     */
   def position: Point
 
-  /** The delta position between this event and the last event relative to the magnification level
+  /** The delta position between this event and the last event relative to the screen
     */
   def movementPosition: Point
 
@@ -591,9 +591,9 @@ object TouchEvent:
     * @param fingerId
     *   The unique identifier for the finger input
     * @param position
-    *   The position of the tap relative to the magnification level
+    *   The position of the tap relative to the screen
     * @param movementPosition
-    *   The delta position between this event and the last event relative to the magnification level
+    *   The delta position between this event and the last event relative to the screen
     * @param pressure
     *   The normalised pressure of the tap (between 0 and 1)
     */
@@ -631,9 +631,9 @@ object TouchEvent:
     * @param fingerId
     *   The unique identifier for the finger input
     * @param position
-    *   The position of the finger release relative to the magnification level
+    *   The position of the finger release relative to the screen
     * @param movementPosition
-    *   The delta position between this event and the last event relative to the magnification level
+    *   The delta position between this event and the last event relative to the screen
     * @param pressure
     *   The normalised pressure of the touch (between 0 and 1)
     */
@@ -674,9 +674,9 @@ object TouchEvent:
     * @param fingerId
     *   The unique identifier for the finger input
     * @param position
-    *   The position of the finger press relative to the magnification level
+    *   The position of the finger press relative to the screen
     * @param movementPosition
-    *   The delta position between this event and the last event relative to the magnification level
+    *   The delta position between this event and the last event relative to the screen
     * @param pressure
     *   The normalised pressure of the touch (between 0 and 1)
     */
@@ -717,9 +717,9 @@ object TouchEvent:
     * @param fingerId
     *   The unique identifier for the finger input
     * @param position
-    *   The position of the finger relative to the magnification level
+    *   The position of the finger relative to the screen
     * @param movementPosition
-    *   The delta position between this event and the last event relative to the magnification level
+    *   The delta position between this event and the last event relative to the screen
     * @param pressure
     *   The normalised pressure of the touch (between 0 and 1)
     */
@@ -749,9 +749,9 @@ object TouchEvent:
     * @param fingerId
     *   The unique identifier for the finger input
     * @param position
-    *   The position of the finger relative to the magnification level
+    *   The position of the finger relative to the screen
     * @param movementPosition
-    *   The delta position between this event and the last event relative to the magnification level
+    *   The delta position between this event and the last event relative to the screen
     * @param pressure
     *   The normalised pressure of the touch (between 0 and 1)
     */
@@ -773,9 +773,9 @@ object TouchEvent:
     * @param fingerId
     *   The unique identifier for the finger input
     * @param position
-    *   The position of the finger relative to the magnification level
+    *   The position of the finger relative to the screen
     * @param movementPosition
-    *   The delta position between this event and the last event relative to the magnification level
+    *   The delta position between this event and the last event relative to the screen
     * @param pressure
     *   The normalised pressure of the touch (between 0 and 1)
     */
@@ -801,9 +801,9 @@ object TouchEvent:
     * @param fingerId
     *   The unique identifier for the finger input
     * @param position
-    *   The position of the finger relative to the magnification level
+    *   The position of the finger relative to the screen
     * @param movementPosition
-    *   The delta position between this event and the last event relative to the magnification level
+    *   The delta position between this event and the last event relative to the screen
     * @param pressure
     *   The normalised pressure of the touch (between 0 and 1)
     */
@@ -825,7 +825,7 @@ sealed trait PenEvent extends PositionalInputEvent:
     */
   def pointerId: PointerId
 
-  /** Coordinates relative to the magnification level
+  /** Coordinates relative to the screen
     */
   def position: Point
 
@@ -841,9 +841,9 @@ object PenEvent:
     * @param pointerId
     *   The unique identifier for the pointer input
     * @param position
-    *   The position of the pen relative to the magnification level
+    *   The position of the pen relative to the screen
     * @param movementPosition
-    *   The delta position between this event and the last event relative to the magnification level
+    *   The delta position between this event and the last event relative to the screen
     * @param pressure
     *   The normalised pressure of the pen (between 0 and 1)
     * @param button
@@ -898,9 +898,9 @@ object PenEvent:
     * @param pointerId
     *   The unique identifier for the pointer input
     * @param position
-    *   The position of the pen relative to the magnification level
+    *   The position of the pen relative to the screen
     * @param movementPosition
-    *   The delta position between this event and the last event relative to the magnification level
+    *   The delta position between this event and the last event relative to the screen
     * @param pressure
     *   The normalised pressure of the pen (between 0 and 1)
     * @param button
@@ -948,9 +948,9 @@ object PenEvent:
     * @param pointerId
     *   The unique identifier for the pointer input
     * @param position
-    *   The position of the pen relative to the magnification level
+    *   The position of the pen relative to the screen
     * @param movementPosition
-    *   The delta position between this event and the last event relative to the magnification level
+    *   The delta position between this event and the last event relative to the screen
     * @param pressure
     *   The normalised pressure of the pen (between 0 and 1)
     * @param button
@@ -1004,9 +1004,9 @@ object PenEvent:
     * @param pointerId
     *   The unique identifier for the pointer input
     * @param position
-    *   The position of the pen relative to the magnification level
+    *   The position of the pen relative to the screen
     * @param movementPosition
-    *   The delta position between this event and the last event relative to the magnification level
+    *   The delta position between this event and the last event relative to the screen
     * @param pressure
     *   The normalised pressure of the pen (between 0 and 1)
     */
@@ -1033,9 +1033,9 @@ object PenEvent:
     * @param pointerId
     *   The unique identifier for the pointer input
     * @param position
-    *   The position of the pen relative to the magnification level
+    *   The position of the pen relative to the screen
     * @param movementPosition
-    *   The delta position between this event and the last event relative to the magnification level
+    *   The delta position between this event and the last event relative to the screen
     * @param pressure
     *   The normalised pressure of the pen (between 0 and 1)
     */
@@ -1054,9 +1054,9 @@ object PenEvent:
     * @param pointerId
     *   The unique identifier for the pointer input
     * @param position
-    *   The position of the pen relative to the magnification level
+    *   The position of the pen relative to the screen
     * @param movementPosition
-    *   The delta position between this event and the last event relative to the magnification level
+    *   The delta position between this event and the last event relative to the screen
     * @param pressure
     *   The normalised pressure of the pen (between 0 and 1)
     */
@@ -1078,9 +1078,9 @@ object PenEvent:
     * @param pointerId
     *   The unique identifier for the pointer input
     * @param position
-    *   The position of the pen relative to the magnification level
+    *   The position of the pen relative to the screen
     * @param movementPosition
-    *   The delta position between this event and the last event relative to the magnification level
+    *   The delta position between this event and the last event relative to the screen
     * @param pressure
     *   The normalised pressure of the pen (between 0 and 1)
     */
@@ -1100,12 +1100,12 @@ end PenEvent
   */
 sealed trait PointerEvent extends PositionalInputEvent:
 
-  /** The width (magnitude on the X axis), of the contact geometry of the pointer relative to the magnification level
+  /** The width (magnitude on the X axis), of the contact geometry of the pointer relative to the screen
     */
   @deprecated("Being removed to simplify Input", "0.22.0")
   def width: Int
 
-  /** The height (magnitude on the Y axis), of the contact geometry of the pointer relative to the magnification level
+  /** The height (magnitude on the Y axis), of the contact geometry of the pointer relative to the screen
     */
   @deprecated("Being removed to simplify Input", "0.22.0")
   def height: Int

--- a/indigo-core/src/indigo/core/input/PositionalInputState.scala
+++ b/indigo-core/src/indigo/core/input/PositionalInputState.scala
@@ -4,19 +4,19 @@ import indigo.core.datatypes.Point
 import indigo.core.datatypes.Rectangle
 
 trait PositionalInputState:
-  /** Coordinates relative to the magnification level, regardless of whether the pointer has a verified position
+  /** Coordinates relative to the screen, regardless of whether the pointer has a verified position
     */
   def position: Point = maybePosition.getOrElse(Point.zero)
 
-  /** Coordinates relative to the magnification level, if the pointer is currently has a position
+  /** Coordinates relative to the screen, if the pointer is currently has a position
     */
   val maybePosition: Option[Point]
 
-  /** The X position relative to the magnification level
+  /** The X position relative to the screen
     */
   def x: Int = position.x
 
-  /** The Y position relative to the magnification level
+  /** The Y position relative to the screen
     */
   def y: Int = position.y
 

--- a/indigo-core/src/indigo/core/render/Magnification.scala
+++ b/indigo-core/src/indigo/core/render/Magnification.scala
@@ -1,0 +1,38 @@
+package indigo.core.render
+
+/** Represents the amount to magnify / scale the pixels by. Automatically clamped to a range of 1 to 16, typical useage
+  * is <= x4.
+  */
+opaque type Magnification = Int
+
+object Magnification:
+
+  private val _min: Int = 1
+  private val _max: Int = 16
+
+  lazy val x1: Magnification =
+    Magnification(_min)
+  lazy val x2: Magnification =
+    Magnification(2)
+  lazy val x3: Magnification =
+    Magnification(3)
+  lazy val x4: Magnification =
+    Magnification(4)
+  lazy val default: Magnification =
+    Magnification.x1
+
+  lazy val Max: Magnification =
+    Magnification(_max)
+  lazy val Min: Magnification =
+    Magnification.x1
+
+  def apply(value: Int): Magnification =
+    clampToRange(value)
+
+  private def clampToRange(value: Int): Magnification =
+    Math.min(_max, Math.max(_min, value))
+
+  extension (m: Magnification)
+    def increase: Magnification = clampToRange(m.toInt + 1)
+    def decrease: Magnification = clampToRange(m.toInt - 1)
+    def toInt: Int              = m

--- a/indigo-core/src/indigo/core/render/Magnification.scala
+++ b/indigo-core/src/indigo/core/render/Magnification.scala
@@ -1,6 +1,6 @@
 package indigo.core.render
 
-/** Represents the amount to magnify / scale the pixels by. Automatically clamped to a range of 1 to 16, typical useage
+/** Represents the amount to magnify / scale the pixels by. Automatically clamped to a range of 1 to 16, typical usage
   * is <= x4.
   */
 opaque type Magnification = Int

--- a/indigo-extras/src/indigoextras/subsystems/Automata.scala
+++ b/indigo-extras/src/indigoextras/subsystems/Automata.scala
@@ -22,7 +22,7 @@ import indigoextras.subsystems.AutomataEvent.*
 final case class Automata[Model](
     poolKey: AutomataPoolKey,
     automaton: Automaton,
-    layerKey: Option[LayerKey],
+    layerKey: LayerKey,
     maxPoolSize: Option[Int]
 ) extends SubSystem[Model]:
   type EventType      = AutomataEvent
@@ -127,11 +127,8 @@ final case class Automata[Model](
 
 object Automata:
 
-  def apply[Model](poolKey: AutomataPoolKey, automaton: Automaton): Automata[Model] =
-    Automata(poolKey, automaton, None, None)
-
   def apply[Model](poolKey: AutomataPoolKey, automaton: Automaton, layerKey: LayerKey): Automata[Model] =
-    Automata(poolKey, automaton, Some(layerKey), None)
+    Automata(poolKey, automaton, layerKey, None)
 
   def renderNoLayer(pool: Batch[SpawnedAutomaton], gameTime: GameTime): AutomatonUpdate =
     AutomatonUpdate.sequence(

--- a/indigo-extras/src/indigoextras/subsystems/FPSCounter.scala
+++ b/indigo-extras/src/indigoextras/subsystems/FPSCounter.scala
@@ -29,7 +29,7 @@ final case class FPSCounter[Model](
     place: (Context, Size) => Point,
     targetFPS: Option[FPS],
     thresholds: Batch[FPSThreshold],
-    layerKey: Option[LayerKey],
+    layerKey: LayerKey,
     fontKey: FontKey,
     fontAsset: AssetName
 ) extends SubSystem[Model]:
@@ -78,9 +78,7 @@ final case class FPSCounter[Model](
     this.copy(targetFPS = None)
 
   def withLayerKey(layerKey: LayerKey): FPSCounter[Model] =
-    this.copy(layerKey = Option(layerKey))
-  def clearLayerKey: FPSCounter[Model] =
-    this.copy(layerKey = None)
+    this.copy(layerKey = layerKey)
 
   def eventFilter: GlobalEvent => Option[EventType] = {
     case FrameTick          => Some(FrameTick)
@@ -174,33 +172,29 @@ object FPSCounter:
   private val defaultPlaceFunction: (Context, Size) => Point =
     (_, _) => Point(0, 0)
 
-  def apply[Model](fontKey: FontKey, fontAsset: AssetName): FPSCounter[Model] =
-    FPSCounter(DefaultId, defaultPlaceFunction, None, Batch.empty, None, fontKey, fontAsset)
-
-  def apply[Model](fontKey: FontKey, fontAsset: AssetName, targetFPS: FPS): FPSCounter[Model] =
-    FPSCounter(DefaultId, defaultPlaceFunction, Option(targetFPS), Batch.empty, None, fontKey, fontAsset)
-
   def apply[Model](fontKey: FontKey, fontAsset: AssetName, layerKey: LayerKey): FPSCounter[Model] =
-    FPSCounter(DefaultId, defaultPlaceFunction, None, Batch.empty, Option(layerKey), fontKey, fontAsset)
+    FPSCounter(DefaultId, defaultPlaceFunction, None, Batch.empty, layerKey, fontKey, fontAsset)
+
+  def apply[Model](fontKey: FontKey, fontAsset: AssetName, layerKey: LayerKey, targetFPS: FPS): FPSCounter[Model] =
+    FPSCounter(DefaultId, defaultPlaceFunction, Option(targetFPS), Batch.empty, layerKey, fontKey, fontAsset)
 
   def apply[Model](
+      id: SubSystemId,
+      position: Point,
       fontKey: FontKey,
       fontAsset: AssetName,
-      targetFPS: FPS,
       layerKey: LayerKey
   ): FPSCounter[Model] =
-    FPSCounter(DefaultId, defaultPlaceFunction, Option(targetFPS), Batch.empty, Option(layerKey), fontKey, fontAsset)
-
-  def apply[Model](id: SubSystemId, position: Point, fontKey: FontKey, fontAsset: AssetName): FPSCounter[Model] =
-    FPSCounter(id, (_, _) => position, None, Batch.empty, None, fontKey, fontAsset)
+    FPSCounter(id, (_, _) => position, None, Batch.empty, layerKey, fontKey, fontAsset)
 
   def apply[Model](
       id: SubSystemId,
       fontKey: FontKey,
       fontAsset: AssetName,
+      layerKey: LayerKey,
       targetFPS: FPS
   ): FPSCounter[Model] =
-    FPSCounter(id, defaultPlaceFunction, Option(targetFPS), Batch.empty, None, fontKey, fontAsset)
+    FPSCounter(id, defaultPlaceFunction, Option(targetFPS), Batch.empty, layerKey, fontKey, fontAsset)
 
   def apply[Model](
       id: SubSystemId,
@@ -208,16 +202,7 @@ object FPSCounter:
       fontAsset: AssetName,
       layerKey: LayerKey
   ): FPSCounter[Model] =
-    FPSCounter(id, defaultPlaceFunction, None, Batch.empty, Option(layerKey), fontKey, fontAsset)
-
-  def apply[Model](
-      id: SubSystemId,
-      fontKey: FontKey,
-      fontAsset: AssetName,
-      targetFPS: FPS,
-      layerKey: LayerKey
-  ): FPSCounter[Model] =
-    FPSCounter(id, defaultPlaceFunction, Option(targetFPS), Batch.empty, Option(layerKey), fontKey, fontAsset)
+    FPSCounter(id, defaultPlaceFunction, None, Batch.empty, layerKey, fontKey, fontAsset)
 
   final case class Move(to: Point) extends GlobalEvent
 

--- a/indigo-extras/src/indigoextras/ui/components/Label.scala
+++ b/indigo-extras/src/indigoextras/ui/components/Label.scala
@@ -56,7 +56,7 @@ object Label:
   def fromText[ReferenceData](textInstance: Text[?]): Label[ReferenceData] =
     Label(
       _ => textInstance.text,
-      (ctx, _) => Outcome(Layer.Content(textInstance.moveTo(ctx.parent.coords.toScreenSpace(ctx.snapGrid)))),
+      (ctx, _) => Outcome(Layer.Content(textInstance.moveTo(ctx.parent.coords.toLocalSpace(ctx.snapGrid)))),
       (ctx, _) => Bounds(ctx.services.bounds.get(textInstance))
     )
 
@@ -70,7 +70,7 @@ object Label:
           Layer.Content(
             textInstance
               .withText(lbl.text(ctx))
-              .moveTo(ctx.parent.coords.toScreenSpace(ctx.snapGrid))
+              .moveTo(ctx.parent.coords.toLocalSpace(ctx.snapGrid))
           )
         ),
       (ctx, lbl) => Bounds(ctx.services.bounds.get(textInstance.withText(lbl)))

--- a/indigo-extras/src/indigoextras/ui/components/MaskedPane.scala
+++ b/indigo-extras/src/indigoextras/ui/components/MaskedPane.scala
@@ -157,7 +157,7 @@ object MaskedPane:
                   Bounds(
                     ctx.parent.coords,
                     model.dimensions
-                  ).toScreenSpace(ctx.snapGrid * ctx.magnification)
+                  ).toScreenSpace(ctx.snapGrid * ctx.magnification.toInt)
                 )
               )
             }

--- a/indigo-extras/src/indigoextras/ui/components/MaskedPane.scala
+++ b/indigo-extras/src/indigoextras/ui/components/MaskedPane.scala
@@ -157,7 +157,7 @@ object MaskedPane:
                   Bounds(
                     ctx.parent.coords,
                     model.dimensions
-                  ).toScreenSpace(ctx.snapGrid * ctx.magnification.toInt)
+                  ).toScreenSpace(ctx.snapGrid, ctx.magnification)
                 )
               )
             }

--- a/indigo-extras/src/indigoextras/ui/components/ScrollPane.scala
+++ b/indigo-extras/src/indigoextras/ui/components/ScrollPane.scala
@@ -333,7 +333,7 @@ object ScrollPane:
             stack.toBatch.map {
               _.withBlendMaterial(
                 LayerMask(
-                  ctx.parent.bounds.toScreenSpace(ctx.snapGrid * ctx.magnification)
+                  ctx.parent.bounds.toScreenSpace(ctx.snapGrid * ctx.magnification.toInt)
                 )
               )
             }

--- a/indigo-extras/src/indigoextras/ui/components/ScrollPane.scala
+++ b/indigo-extras/src/indigoextras/ui/components/ScrollPane.scala
@@ -333,7 +333,7 @@ object ScrollPane:
             stack.toBatch.map {
               _.withBlendMaterial(
                 LayerMask(
-                  ctx.parent.bounds.toScreenSpace(ctx.snapGrid * ctx.magnification.toInt)
+                  ctx.parent.bounds.toScreenSpace(ctx.snapGrid, ctx.magnification)
                 )
               )
             }

--- a/indigo-extras/src/indigoextras/ui/datatypes/Bounds.scala
+++ b/indigo-extras/src/indigoextras/ui/datatypes/Bounds.scala
@@ -22,8 +22,20 @@ object Bounds:
     inline def unsafeToRectangle: Rectangle = r
     inline def coords: Coords               = Coords(r.position)
     inline def dimensions: Dimensions       = Dimensions(r.size)
-    inline def toScreenSpace(charSize: Size): Rectangle =
+
+    /** Converts this into a 1:1 local coordinate space shared with the surrounding entities, i.e. magnification is
+      * being handled for us, elsewhere. Typically used for rendering entities into layers where magnification will be
+      * applied at the surrounding `LayerEntry` level.
+      */
+    inline def toLocalSpace(charSize: Size): Rectangle =
       Rectangle(r.position * charSize.toPoint, r.size * charSize)
+
+    /** Converts this into screen space, i.e. the coordinates align with drawn pixels, e.g. for mouse/pointer hit
+      * detection. To do that, magnification must be taken into consideration explicitly.
+      */
+    inline def toScreenSpace(charSize: Size, magnification: Magnification): Rectangle =
+      val cs = charSize * magnification.toInt
+      Rectangle(r.position * cs.toPoint, r.size * cs)
 
     inline def x: Int      = r.x
     inline def y: Int      = r.y

--- a/indigo-extras/src/indigoextras/ui/datatypes/Coords.scala
+++ b/indigo-extras/src/indigoextras/ui/datatypes/Coords.scala
@@ -12,17 +12,31 @@ object Coords:
   inline def apply(x: Int, y: Int): Coords = Point(x, y)
   inline def apply(point: Point): Coords   = point
 
-  def fromScreenSpace(pt: Point, charSize: Size): Coords =
-    Coords(pt / charSize.toPoint)
+  /** Converts a point in screen space (i.e. coordinates aligned with drawn pixels, such as a raw pointer position) back
+    * into grid `Coords`. As with `toScreenSpace`, magnification must be taken into consideration explicitly.
+    */
+  def fromScreenSpace(pt: Point, charSize: Size, magnification: Magnification): Coords =
+    Coords(pt / (charSize * magnification.toInt).toPoint)
 
   val zero: Coords = Coords(0, 0)
   val one: Coords  = Coords(1, 1)
 
   extension (c: Coords)
-    private[datatypes] inline def toPoint: Point    = c
-    inline def unsafeToPoint: Point                 = c
-    inline def toDimensions: Dimensions             = Dimensions(c.toSize)
-    inline def toScreenSpace(snapGrid: Size): Point = c * snapGrid.toPoint
+    private[datatypes] inline def toPoint: Point = c
+    inline def unsafeToPoint: Point              = c
+    inline def toDimensions: Dimensions          = Dimensions(c.toSize)
+
+    /** Converts this into a 1:1 local coordinate space shared with the surrounding entities, i.e. magnification is
+      * being handled for us, elsewhere. Typically used for rendering entities into layers where magnification will be
+      * applied at the surrounding `LayerEntry` level.
+      */
+    inline def toLocalSpace(charSize: Size): Point = c * charSize.toPoint
+
+    /** Converts this into screen space, i.e. the coordinates align with drawn pixels, e.g. for mouse/pointer hit
+      * detection. To do that, magnification must be taken into consideration explicitly.
+      */
+    inline def toScreenSpace(charSize: Size, magnification: Magnification): Point =
+      c * (charSize * magnification.toInt).toPoint
 
     inline def x: Int = c.x
     inline def y: Int = c.y

--- a/indigo-extras/src/indigoextras/ui/datatypes/Dimensions.scala
+++ b/indigo-extras/src/indigoextras/ui/datatypes/Dimensions.scala
@@ -16,10 +16,21 @@ object Dimensions:
   val one: Dimensions  = Dimensions(1, 1)
 
   extension (d: Dimensions)
-    private[datatypes] inline def toSize: Size     = d
-    inline def unsafeToSize: Size                  = d
-    inline def toCoords: Coords                    = Coords(d.toPoint)
-    inline def toScreenSpace(charSize: Size): Size = d * charSize
+    private[datatypes] inline def toSize: Size = d
+    inline def unsafeToSize: Size              = d
+    inline def toCoords: Coords                = Coords(d.toPoint)
+
+    /** Converts this into a 1:1 local coordinate space shared with the surrounding entities, i.e. magnification is
+      * being handled for us, elsewhere. Typically used for rendering entities into layers where magnification will be
+      * applied at the surrounding `LayerEntry` level.
+      */
+    inline def toLocalSpace(charSize: Size): Size = d * charSize
+
+    /** Converts this into screen space, i.e. the coordinates align with drawn pixels, e.g. for mouse/pointer hit
+      * detection. To do that, magnification must be taken into consideration explicitly.
+      */
+    inline def toScreenSpace(charSize: Size, magnification: Magnification): Size =
+      d * (charSize * magnification.toInt)
 
     inline def width: Int  = d.width
     inline def height: Int = d.height

--- a/indigo-extras/src/indigoextras/ui/datatypes/Parent.scala
+++ b/indigo-extras/src/indigoextras/ui/datatypes/Parent.scala
@@ -1,12 +1,9 @@
 package indigoextras.ui.datatypes
 
 import indigo.core.datatypes.Rectangle
-import indigo.core.datatypes.Size
 
 final case class Parent(bounds: Bounds, additionalOffset: Coords):
 
-  def toRectangle(snapGrid: Size): Rectangle =
-    bounds.toScreenSpace(snapGrid)
   lazy val unsafeToRectangle: Rectangle =
     bounds.unsafeToRectangle
 

--- a/indigo-extras/src/indigoextras/ui/datatypes/UIContext.scala
+++ b/indigo-extras/src/indigoextras/ui/datatypes/UIContext.scala
@@ -20,7 +20,7 @@ final case class UIContext[ReferenceData](
     state == UIState.Active
 
   lazy val pointerCoords: Coords =
-    Coords.fromScreenSpace(_pointerCoords.unsafeToPoint, snapGrid * magnification.toInt)
+    Coords.fromScreenSpace(_pointerCoords.unsafeToPoint, snapGrid, magnification)
 
   def withParent(newParent: Parent): UIContext[ReferenceData] =
     this.copy(parent = newParent)

--- a/indigo-extras/src/indigoextras/ui/datatypes/UIContext.scala
+++ b/indigo-extras/src/indigoextras/ui/datatypes/UIContext.scala
@@ -9,7 +9,7 @@ final case class UIContext[ReferenceData](
     snapGrid: Size,
     _pointerCoords: Coords,
     state: UIState,
-    magnification: Int,
+    magnification: Magnification,
     // The following are all the same as in SubSystemContext
     reference: ReferenceData,
     frame: Context.Frame,
@@ -20,7 +20,7 @@ final case class UIContext[ReferenceData](
     state == UIState.Active
 
   lazy val pointerCoords: Coords =
-    Coords(_pointerCoords.unsafeToPoint / snapGrid.toPoint)
+    Coords.fromScreenSpace(_pointerCoords.unsafeToPoint, snapGrid * magnification.toInt)
 
   def withParent(newParent: Parent): UIContext[ReferenceData] =
     this.copy(parent = newParent)
@@ -61,7 +61,7 @@ final case class UIContext[ReferenceData](
   def makeInActive: UIContext[ReferenceData] =
     withState(UIState.InActive)
 
-  def withMagnification(newMagnification: Int): UIContext[ReferenceData] =
+  def withMagnification(newMagnification: Magnification): UIContext[ReferenceData] =
     this.copy(magnification = newMagnification)
 
   def withReferenceData[NewReferenceData](newReference: NewReferenceData): UIContext[NewReferenceData] =
@@ -74,7 +74,7 @@ object UIContext:
   def apply[ReferenceData](
       subSystemContext: SubSystemContext[ReferenceData],
       snapGrid: Size,
-      magnification: Int
+      magnification: Magnification
   ): UIContext[ReferenceData] =
     UIContext(
       Parent.default,
@@ -87,27 +87,27 @@ object UIContext:
       subSystemContext.services
     )
 
-  def apply(ctx: Context, magnification: Int): UIContext[Unit] =
+  def apply(ctx: Context, magnification: Magnification): UIContext[Unit] =
     fromContext(ctx, (), magnification)
 
   def apply(ctx: Context): UIContext[Unit] =
-    fromContext(ctx, (), 1)
+    fromContext(ctx, (), Magnification.x1)
 
-  def apply(ctx: SceneContext, magnification: Int): UIContext[Unit] =
+  def apply(ctx: SceneContext, magnification: Magnification): UIContext[Unit] =
     fromSceneContext(ctx, (), magnification)
 
   def apply(ctx: SceneContext): UIContext[Unit] =
-    fromSceneContext(ctx, (), 1)
+    fromSceneContext(ctx, (), Magnification.x1)
 
   def fromContext[ReferenceData](
       ctx: Context,
       reference: ReferenceData,
-      magnification: Int
+      magnification: Magnification
   ): UIContext[ReferenceData] =
     UIContext(
       Parent.default,
       Size.one,
-      Coords(ctx.frame.input.pointer.position / Point.one),
+      Coords(ctx.frame.input.pointer.position),
       UIState.Active,
       magnification,
       reference,
@@ -118,14 +118,14 @@ object UIContext:
   def fromSceneContext[ReferenceData](
       ctx: SceneContext,
       reference: ReferenceData,
-      magnification: Int
+      magnification: Magnification
   ): UIContext[ReferenceData] =
     fromContext(ctx.toContext, reference, magnification)
 
   def fromSubSystemContext[ReferenceData](
       ctx: SubSystemContext[?],
       reference: ReferenceData,
-      magnification: Int
+      magnification: Magnification
   ): UIContext[ReferenceData] =
     fromContext(ctx.toContext, reference, magnification)
 

--- a/indigo-extras/src/indigoextras/ui/window/Window.scala
+++ b/indigo-extras/src/indigoextras/ui/window/Window.scala
@@ -25,14 +25,14 @@ final case class Window[A, ReferenceData](
     activeCheck: UIContext[ReferenceData] => WindowActive
 ):
 
-  def bounds(viewport: Rectangle, magnification: Int): Bounds =
+  def bounds(viewport: Rectangle, magnification: Magnification): Bounds =
     position match
       case WindowPosition.Fixed(coords) =>
         Bounds(coords, dimensions)
 
       case WindowPosition.Anchored(anchor) =>
         Bounds(
-          anchor.calculatePosition(Dimensions(viewport.size) / magnification, dimensions),
+          anchor.calculatePosition(Dimensions(viewport.size) / magnification.toInt, dimensions),
           dimensions
         )
 

--- a/indigo-extras/src/indigoextras/ui/window/WindowContext.scala
+++ b/indigo-extras/src/indigoextras/ui/window/WindowContext.scala
@@ -1,5 +1,6 @@
 package indigoextras.ui.window
 
+import indigo.core.render.Magnification
 import indigoextras.ui.datatypes.Bounds
 import indigoextras.ui.datatypes.UIContext
 
@@ -8,7 +9,7 @@ final case class WindowContext[ReferenceData](
     bounds: Bounds,
     hasFocus: Boolean,
     pointerIsOver: Boolean,
-    magnification: Int
+    magnification: Magnification
 )
 
 object WindowContext:
@@ -23,5 +24,5 @@ object WindowContext:
       model.bounds(context.frame.viewport, context.magnification),
       model.hasFocus,
       viewModel.pointerIsOver,
-      viewModel.magnification
+      context.magnification
     )

--- a/indigo-extras/src/indigoextras/ui/window/WindowEvent.scala
+++ b/indigo-extras/src/indigoextras/ui/window/WindowEvent.scala
@@ -60,29 +60,29 @@ enum WindowEvent extends GlobalEvent derives CanEqual:
   /** Changes the bounds of a window */
   case Transform(id: WindowId, bounds: Bounds, space: Space)
 
-  // /** Changes the magnification of all windows */
-  // case ChangeMagnification(newMagnification: Magnification)
+  /** Changes the magnification of all windows */
+  case ChangeMagnification(newMagnification: Magnification)
 
   /** Tells a window request its content to refresh */
   case Refresh(id: WindowId)
 
   def windowId: Option[WindowId] =
     this match
-      case PointerOver(id)     => Some(id)
-      case PointerOut(id)      => Some(id)
-      case Resized(id)         => Some(id)
-      case Opened(id)          => Some(id)
-      case Closed(id)          => Some(id)
-      case Open(id)            => Some(id)
-      case OpenAt(id, _)       => Some(id)
-      case Close(id)           => Some(id)
-      case Toggle(id)          => Some(id)
-      case Move(id, _, _)      => Some(id)
-      case Anchor(id, _)       => Some(id)
-      case Resize(id, _, _)    => Some(id)
-      case Transform(id, _, _) => Some(id)
-      case Refresh(id)         => Some(id)
-      case Focus(id)           => Some(id)
-      case GiveFocusAt(_)      => None
-      // case ChangeMagnification(_) => None
-      case CloseFocused => None
+      case PointerOver(id)        => Some(id)
+      case PointerOut(id)         => Some(id)
+      case Resized(id)            => Some(id)
+      case Opened(id)             => Some(id)
+      case Closed(id)             => Some(id)
+      case Open(id)               => Some(id)
+      case OpenAt(id, _)          => Some(id)
+      case Close(id)              => Some(id)
+      case Toggle(id)             => Some(id)
+      case Move(id, _, _)         => Some(id)
+      case Anchor(id, _)          => Some(id)
+      case Resize(id, _, _)       => Some(id)
+      case Transform(id, _, _)    => Some(id)
+      case Refresh(id)            => Some(id)
+      case Focus(id)              => Some(id)
+      case GiveFocusAt(_)         => None
+      case ChangeMagnification(_) => None
+      case CloseFocused           => None

--- a/indigo-extras/src/indigoextras/ui/window/WindowEvent.scala
+++ b/indigo-extras/src/indigoextras/ui/window/WindowEvent.scala
@@ -60,29 +60,29 @@ enum WindowEvent extends GlobalEvent derives CanEqual:
   /** Changes the bounds of a window */
   case Transform(id: WindowId, bounds: Bounds, space: Space)
 
-  /** Changes the magnification of all windows */
-  case ChangeMagnification(newMagnification: Int)
+  // /** Changes the magnification of all windows */
+  // case ChangeMagnification(newMagnification: Magnification)
 
   /** Tells a window request its content to refresh */
   case Refresh(id: WindowId)
 
   def windowId: Option[WindowId] =
     this match
-      case PointerOver(id)        => Some(id)
-      case PointerOut(id)         => Some(id)
-      case Resized(id)            => Some(id)
-      case Opened(id)             => Some(id)
-      case Closed(id)             => Some(id)
-      case Open(id)               => Some(id)
-      case OpenAt(id, _)          => Some(id)
-      case Close(id)              => Some(id)
-      case Toggle(id)             => Some(id)
-      case Move(id, _, _)         => Some(id)
-      case Anchor(id, _)          => Some(id)
-      case Resize(id, _, _)       => Some(id)
-      case Transform(id, _, _)    => Some(id)
-      case Refresh(id)            => Some(id)
-      case Focus(id)              => Some(id)
-      case GiveFocusAt(_)         => None
-      case ChangeMagnification(_) => None
-      case CloseFocused           => None
+      case PointerOver(id)     => Some(id)
+      case PointerOut(id)      => Some(id)
+      case Resized(id)         => Some(id)
+      case Opened(id)          => Some(id)
+      case Closed(id)          => Some(id)
+      case Open(id)            => Some(id)
+      case OpenAt(id, _)       => Some(id)
+      case Close(id)           => Some(id)
+      case Toggle(id)          => Some(id)
+      case Move(id, _, _)      => Some(id)
+      case Anchor(id, _)       => Some(id)
+      case Resize(id, _, _)    => Some(id)
+      case Transform(id, _, _) => Some(id)
+      case Refresh(id)         => Some(id)
+      case Focus(id)           => Some(id)
+      case GiveFocusAt(_)      => None
+      // case ChangeMagnification(_) => None
+      case CloseFocused => None

--- a/indigo-extras/src/indigoextras/ui/window/WindowManager.scala
+++ b/indigo-extras/src/indigoextras/ui/window/WindowManager.scala
@@ -25,7 +25,7 @@ final case class WindowManager[StartUpData, Model, RefData](
 
   def initialModel: Outcome[ModelHolder[ReferenceData]] =
     Outcome(
-      ModelHolder.initial(windows /*, initialMagnification*/ )
+      ModelHolder.initial(windows, initialMagnification)
     )
 
   def update(
@@ -35,13 +35,13 @@ final case class WindowManager[StartUpData, Model, RefData](
     e =>
       for {
         updatedModel <- WindowManager.updateModel[ReferenceData](
-          UIContext(context, snapGrid, initialMagnification),
+          UIContext(context, snapGrid, model.viewModel.magnification),
           model.model
         )(e)
 
         updatedViewModel <-
           WindowManager.updateViewModel[ReferenceData](
-            UIContext(context, snapGrid, initialMagnification),
+            UIContext(context, snapGrid, model.viewModel.magnification),
             updatedModel,
             model.viewModel
           )(e)
@@ -53,7 +53,7 @@ final case class WindowManager[StartUpData, Model, RefData](
   ): Outcome[SceneUpdateFragment] =
     WindowManager.present(
       layerKey,
-      UIContext(context, snapGrid, initialMagnification),
+      UIContext(context, snapGrid, model.viewModel.magnification),
       model.model,
       model.viewModel
     )
@@ -285,8 +285,8 @@ object WindowManager:
     case WindowEvent.PointerOut(_) =>
       Outcome(model)
 
-    // case WindowEvent.ChangeMagnification(_) =>
-    //   Outcome(model)
+    case WindowEvent.ChangeMagnification(_) =>
+      Outcome(model)
 
     case WindowEvent.CloseFocused =>
       model.focused match
@@ -305,8 +305,8 @@ object WindowManager:
       model: WindowManagerModel[ReferenceData],
       viewModel: WindowManagerViewModel[ReferenceData]
   ): GlobalEvent => Outcome[WindowManagerViewModel[ReferenceData]] =
-    // case WindowEvent.ChangeMagnification(next) =>
-    //   Outcome(viewModel.changeMagnification(next))
+    case WindowEvent.ChangeMagnification(next) =>
+      Outcome(viewModel.changeMagnification(next))
 
     case e =>
       val windowUnderPointer =
@@ -381,10 +381,10 @@ final case class ModelHolder[ReferenceData](
 )
 object ModelHolder:
   def initial[ReferenceData](
-      windows: Batch[Window[?, ReferenceData]] // ,
-      // magnification: Magnification
+      windows: Batch[Window[?, ReferenceData]],
+      magnification: Magnification
   ): ModelHolder[ReferenceData] =
     ModelHolder(
       WindowManagerModel.initial.register(windows),
-      WindowManagerViewModel.initial // (magnification)
+      WindowManagerViewModel.initial(magnification)
     )

--- a/indigo-extras/src/indigoextras/ui/window/WindowManager.scala
+++ b/indigo-extras/src/indigoextras/ui/window/WindowManager.scala
@@ -6,11 +6,11 @@ import indigoextras.ui.datatypes.UIState
 
 final case class WindowManager[StartUpData, Model, RefData](
     id: SubSystemId,
-    initialMagnification: Int,
+    initialMagnification: Magnification,
     snapGrid: Size,
     extractReference: Model => RefData,
     startUpData: StartUpData,
-    layerKey: Option[LayerKey],
+    layerKey: LayerKey,
     windows: Batch[Window[?, RefData]]
 ) extends SubSystem[Model]:
   type EventType      = GlobalEvent
@@ -25,7 +25,7 @@ final case class WindowManager[StartUpData, Model, RefData](
 
   def initialModel: Outcome[ModelHolder[ReferenceData]] =
     Outcome(
-      ModelHolder.initial(windows, initialMagnification)
+      ModelHolder.initial(windows /*, initialMagnification*/ )
     )
 
   def update(
@@ -35,13 +35,13 @@ final case class WindowManager[StartUpData, Model, RefData](
     e =>
       for {
         updatedModel <- WindowManager.updateModel[ReferenceData](
-          UIContext(context, snapGrid, model.viewModel.magnification),
+          UIContext(context, snapGrid, initialMagnification),
           model.model
         )(e)
 
         updatedViewModel <-
           WindowManager.updateViewModel[ReferenceData](
-            UIContext(context, snapGrid, model.viewModel.magnification),
+            UIContext(context, snapGrid, initialMagnification),
             updatedModel,
             model.viewModel
           )(e)
@@ -53,7 +53,7 @@ final case class WindowManager[StartUpData, Model, RefData](
   ): Outcome[SceneUpdateFragment] =
     WindowManager.present(
       layerKey,
-      UIContext(context, snapGrid, model.viewModel.magnification),
+      UIContext(context, snapGrid, initialMagnification),
       model.model,
       model.viewModel
     )
@@ -105,43 +105,47 @@ final case class WindowManager[StartUpData, Model, RefData](
   /** Allows you to set the layer key that the WindowManager will use to present the windows.
     */
   def withLayerKey(newLayerKey: LayerKey): WindowManager[StartUpData, Model, ReferenceData] =
-    this.copy(layerKey = Option(newLayerKey))
+    this.copy(layerKey = newLayerKey)
 
 object WindowManager:
 
   /** Creates a WindowManager instance with no snap grid, that respects the magnification specified.
     */
-  def apply[Model](id: SubSystemId): WindowManager[Unit, Model, Unit] =
-    WindowManager(id, 1, Size(1), _ => (), (), None, Batch.empty)
+  def apply[Model](id: SubSystemId, layerKey: LayerKey): WindowManager[Unit, Model, Unit] =
+    WindowManager(id, Magnification.x1, Size(1), _ => (), (), layerKey, Batch.empty)
 
   /** Creates a WindowManager instance with no snap grid, that respects the magnification specified.
     */
   def apply[Model](
       id: SubSystemId,
-      magnification: Int
+      layerKey: LayerKey,
+      magnification: Magnification
   ): WindowManager[Unit, Model, Unit] =
-    WindowManager(id, magnification, Size(1), _ => (), (), None, Batch.empty)
+    WindowManager(id, magnification, Size(1), _ => (), (), layerKey, Batch.empty)
 
   /** Creates a WindowManager instance with no snap grid, that respects the magnification specified.
     */
   def apply[Model](
       id: SubSystemId,
-      magnification: Int,
+      layerKey: LayerKey,
+      magnification: Magnification,
       snapGrid: Size
   ): WindowManager[Unit, Model, Unit] =
-    WindowManager(id, magnification, snapGrid, _ => (), (), None, Batch.empty)
+    WindowManager(id, magnification, snapGrid, _ => (), (), layerKey, Batch.empty)
 
   def apply[Model, ReferenceData](
       id: SubSystemId,
-      magnification: Int,
+      layerKey: LayerKey,
+      magnification: Magnification,
       snapGrid: Size,
       extractReference: Model => ReferenceData
   ): WindowManager[Unit, Model, ReferenceData] =
-    WindowManager(id, magnification, snapGrid, extractReference, (), None, Batch.empty)
+    WindowManager(id, magnification, snapGrid, extractReference, (), layerKey, Batch.empty)
 
   def apply[StartUpData, Model, ReferenceData](
       id: SubSystemId,
-      magnification: Int,
+      layerKey: LayerKey,
+      magnification: Magnification,
       snapGrid: Size,
       extractReference: Model => ReferenceData,
       startUpData: StartUpData
@@ -152,25 +156,7 @@ object WindowManager:
       snapGrid,
       extractReference,
       startUpData,
-      None,
-      Batch.empty
-    )
-
-  def apply[StartUpData, Model, ReferenceData](
-      id: SubSystemId,
-      magnification: Int,
-      snapGrid: Size,
-      extractReference: Model => ReferenceData,
-      startUpData: StartUpData,
-      layerKey: LayerKey
-  ): WindowManager[StartUpData, Model, ReferenceData] =
-    WindowManager(
-      id,
-      magnification,
-      snapGrid,
-      extractReference,
-      startUpData,
-      Option(layerKey),
+      layerKey,
       Batch.empty
     )
 
@@ -299,8 +285,8 @@ object WindowManager:
     case WindowEvent.PointerOut(_) =>
       Outcome(model)
 
-    case WindowEvent.ChangeMagnification(_) =>
-      Outcome(model)
+    // case WindowEvent.ChangeMagnification(_) =>
+    //   Outcome(model)
 
     case WindowEvent.CloseFocused =>
       model.focused match
@@ -319,8 +305,8 @@ object WindowManager:
       model: WindowManagerModel[ReferenceData],
       viewModel: WindowManagerViewModel[ReferenceData]
   ): GlobalEvent => Outcome[WindowManagerViewModel[ReferenceData]] =
-    case WindowEvent.ChangeMagnification(next) =>
-      Outcome(viewModel.changeMagnification(next))
+    // case WindowEvent.ChangeMagnification(next) =>
+    //   Outcome(viewModel.changeMagnification(next))
 
     case e =>
       val windowUnderPointer =
@@ -333,7 +319,7 @@ object WindowManager:
           else
             prunedVM.windows.find(_.id == m.id) match
               case None =>
-                Batch(Outcome(WindowViewModel.initial(m.id, viewModel.magnification)))
+                Batch(Outcome(WindowViewModel.initial(m.id, context.magnification)))
 
               case Some(vm) =>
                 Batch(
@@ -351,7 +337,7 @@ object WindowManager:
       updated.sequence.map(vm => viewModel.copy(windows = vm))
 
   private[window] def present[ReferenceData](
-      layerKey: Option[LayerKey],
+      layerKey: LayerKey,
       context: UIContext[ReferenceData],
       model: WindowManagerModel[ReferenceData],
       viewModel: WindowManagerViewModel[ReferenceData]
@@ -383,16 +369,10 @@ object WindowManager:
         .sequence
 
     windowLayers.map { layers =>
-      layerKey match
-        case None =>
-          SceneUpdateFragment(
-            LayerEntry(Layer.Stack(layers))
-          )
-
-        case Some(key) =>
-          SceneUpdateFragment(
-            LayerEntry(key -> Layer.Stack(layers))
-          )
+      SceneUpdateFragment(
+        LayerEntry(layerKey, Layer.Stack(layers))
+          .withMagnification(context.magnification)
+      )
     }
 
 final case class ModelHolder[ReferenceData](
@@ -401,10 +381,10 @@ final case class ModelHolder[ReferenceData](
 )
 object ModelHolder:
   def initial[ReferenceData](
-      windows: Batch[Window[?, ReferenceData]],
-      magnification: Int
+      windows: Batch[Window[?, ReferenceData]] // ,
+      // magnification: Magnification
   ): ModelHolder[ReferenceData] =
     ModelHolder(
       WindowManagerModel.initial.register(windows),
-      WindowManagerViewModel.initial(magnification)
+      WindowManagerViewModel.initial // (magnification)
     )

--- a/indigo-extras/src/indigoextras/ui/window/WindowManager.scala
+++ b/indigo-extras/src/indigoextras/ui/window/WindowManager.scala
@@ -319,7 +319,7 @@ object WindowManager:
           else
             prunedVM.windows.find(_.id == m.id) match
               case None =>
-                Batch(Outcome(WindowViewModel.initial(m.id, context.magnification)))
+                Batch(Outcome(WindowViewModel.initial(m.id)))
 
               case Some(vm) =>
                 Batch(

--- a/indigo-extras/src/indigoextras/ui/window/WindowManagerModel.scala
+++ b/indigo-extras/src/indigoextras/ui/window/WindowManagerModel.scala
@@ -78,7 +78,7 @@ final case class WindowManagerModel[ReferenceData](windows: Batch[Window[?, Refe
   def focused: Option[Window[?, ReferenceData]] =
     windows.find(_.hasFocus)
 
-  def windowAt(coords: Coords, viewport: Rectangle, magnification: Int): Option[WindowId] =
+  def windowAt(coords: Coords, viewport: Rectangle, magnification: Magnification): Option[WindowId] =
     windows.reverse.find(_.bounds(viewport, magnification).contains(coords)).map(_.id)
 
   def moveTo(
@@ -86,7 +86,7 @@ final case class WindowManagerModel[ReferenceData](windows: Batch[Window[?, Refe
       position: Coords,
       space: Space,
       viewport: Rectangle,
-      magnification: Int
+      magnification: Magnification
   ): WindowManagerModel[ReferenceData] =
     this.copy(
       windows = windows.map { w =>
@@ -118,7 +118,7 @@ final case class WindowManagerModel[ReferenceData](windows: Batch[Window[?, Refe
       dimensions: Dimensions,
       space: Space,
       viewport: Rectangle,
-      magnification: Int
+      magnification: Magnification
   ): WindowManagerModel[ReferenceData] =
     this.copy(
       windows = windows.map { w =>
@@ -139,7 +139,7 @@ final case class WindowManagerModel[ReferenceData](windows: Batch[Window[?, Refe
       bounds: Bounds,
       space: Space,
       viewport: Rectangle,
-      magnification: Int
+      magnification: Magnification
   ): WindowManagerModel[ReferenceData] =
     this.copy(
       windows = windows.map { w =>

--- a/indigo-extras/src/indigoextras/ui/window/WindowManagerViewModel.scala
+++ b/indigo-extras/src/indigoextras/ui/window/WindowManagerViewModel.scala
@@ -4,8 +4,8 @@ import indigo.*
 import indigoextras.ui.datatypes.UIContext
 
 final case class WindowManagerViewModel[ReferenceData](
-    windows: Batch[WindowViewModel[ReferenceData]],
-    magnification: Int
+    windows: Batch[WindowViewModel[ReferenceData]] // ,
+    // magnification: Magnification
 ):
   def prune(model: WindowManagerModel[ReferenceData]): WindowManagerViewModel[ReferenceData] =
     this.copy(windows = windows.filter(w => model.windows.exists(_.id == w.id)))
@@ -23,12 +23,12 @@ final case class WindowManagerViewModel[ReferenceData](
   def pointerIsOver: Batch[WindowId] =
     windows.collect { case wvm if wvm.pointerIsOver => wvm.id }
 
-  def changeMagnification(next: Int): WindowManagerViewModel[ReferenceData] =
-    this.copy(
-      windows = windows.map(_.copy(magnification = next)),
-      magnification = next
-    )
+  // def changeMagnification(next: Magnification): WindowManagerViewModel[ReferenceData] =
+  //   this.copy(
+  //     windows = windows.map(_.copy(magnification = next)),
+  //     magnification = next
+  //   )
 
 object WindowManagerViewModel:
-  def initial[ReferenceData](magnification: Int): WindowManagerViewModel[ReferenceData] =
-    WindowManagerViewModel(Batch.empty, magnification)
+  def initial[ReferenceData] /*(magnification: Magnification)*/: WindowManagerViewModel[ReferenceData] =
+    WindowManagerViewModel(Batch.empty /*, magnification*/ )

--- a/indigo-extras/src/indigoextras/ui/window/WindowManagerViewModel.scala
+++ b/indigo-extras/src/indigoextras/ui/window/WindowManagerViewModel.scala
@@ -4,8 +4,8 @@ import indigo.*
 import indigoextras.ui.datatypes.UIContext
 
 final case class WindowManagerViewModel[ReferenceData](
-    windows: Batch[WindowViewModel[ReferenceData]] // ,
-    // magnification: Magnification
+    windows: Batch[WindowViewModel[ReferenceData]],
+    magnification: Magnification
 ):
   def prune(model: WindowManagerModel[ReferenceData]): WindowManagerViewModel[ReferenceData] =
     this.copy(windows = windows.filter(w => model.windows.exists(_.id == w.id)))
@@ -23,12 +23,12 @@ final case class WindowManagerViewModel[ReferenceData](
   def pointerIsOver: Batch[WindowId] =
     windows.collect { case wvm if wvm.pointerIsOver => wvm.id }
 
-  // def changeMagnification(next: Magnification): WindowManagerViewModel[ReferenceData] =
-  //   this.copy(
-  //     windows = windows.map(_.copy(magnification = next)),
-  //     magnification = next
-  //   )
+  def changeMagnification(next: Magnification): WindowManagerViewModel[ReferenceData] =
+    this.copy(
+      windows = windows.map(_.copy(magnification = next)),
+      magnification = next
+    )
 
 object WindowManagerViewModel:
-  def initial[ReferenceData] /*(magnification: Magnification)*/: WindowManagerViewModel[ReferenceData] =
-    WindowManagerViewModel(Batch.empty /*, magnification*/ )
+  def initial[ReferenceData](magnification: Magnification): WindowManagerViewModel[ReferenceData] =
+    WindowManagerViewModel(Batch.empty, magnification)

--- a/indigo-extras/src/indigoextras/ui/window/WindowManagerViewModel.scala
+++ b/indigo-extras/src/indigoextras/ui/window/WindowManagerViewModel.scala
@@ -24,10 +24,7 @@ final case class WindowManagerViewModel[ReferenceData](
     windows.collect { case wvm if wvm.pointerIsOver => wvm.id }
 
   def changeMagnification(next: Magnification): WindowManagerViewModel[ReferenceData] =
-    this.copy(
-      windows = windows.map(_.copy(magnification = next)),
-      magnification = next
-    )
+    this.copy(magnification = next)
 
 object WindowManagerViewModel:
   def initial[ReferenceData](magnification: Magnification): WindowManagerViewModel[ReferenceData] =

--- a/indigo-extras/src/indigoextras/ui/window/WindowViewModel.scala
+++ b/indigo-extras/src/indigoextras/ui/window/WindowViewModel.scala
@@ -7,8 +7,7 @@ import indigoextras.ui.datatypes.UIContext
 final case class WindowViewModel[ReferenceData](
     id: WindowId,
     modelHashCode: Int,
-    pointerIsOver: Boolean,
-    magnification: Magnification
+    pointerIsOver: Boolean
 ):
 
   def update[A](
@@ -20,12 +19,11 @@ final case class WindowViewModel[ReferenceData](
 
 object WindowViewModel:
 
-  def initial[ReferenceData](id: WindowId, magnification: Magnification): WindowViewModel[ReferenceData] =
+  def initial[ReferenceData](id: WindowId): WindowViewModel[ReferenceData] =
     WindowViewModel(
       id,
       0,
-      false,
-      magnification
+      false
     )
 
   def updateViewModel[A, ReferenceData](
@@ -42,7 +40,7 @@ object WindowViewModel:
     case PointerEvent.Move(pt)
         if viewModel.pointerIsOver && !model
           .bounds(context.frame.viewport, context.magnification)
-          .toScreenSpace(context.snapGrid * context.magnification.toInt)
+          .toScreenSpace(context.snapGrid, context.magnification)
           .contains(pt) =>
       Outcome(viewModel.copy(pointerIsOver = false))
         .addGlobalEvents(WindowEvent.PointerOut(model.id))
@@ -50,7 +48,7 @@ object WindowViewModel:
     case PointerEvent.Move(pt)
         if !viewModel.pointerIsOver && model
           .bounds(context.frame.viewport, context.magnification)
-          .toScreenSpace(context.snapGrid * context.magnification.toInt)
+          .toScreenSpace(context.snapGrid, context.magnification)
           .contains(pt) =>
       Outcome(viewModel.copy(pointerIsOver = true))
         .addGlobalEvents(WindowEvent.PointerOver(model.id))

--- a/indigo-extras/src/indigoextras/ui/window/WindowViewModel.scala
+++ b/indigo-extras/src/indigoextras/ui/window/WindowViewModel.scala
@@ -8,7 +8,7 @@ final case class WindowViewModel[ReferenceData](
     id: WindowId,
     modelHashCode: Int,
     pointerIsOver: Boolean,
-    magnification: Int
+    magnification: Magnification
 ):
 
   def update[A](
@@ -20,7 +20,7 @@ final case class WindowViewModel[ReferenceData](
 
 object WindowViewModel:
 
-  def initial[ReferenceData](id: WindowId, magnification: Int): WindowViewModel[ReferenceData] =
+  def initial[ReferenceData](id: WindowId, magnification: Magnification): WindowViewModel[ReferenceData] =
     WindowViewModel(
       id,
       0,
@@ -42,7 +42,7 @@ object WindowViewModel:
     case PointerEvent.Move(pt)
         if viewModel.pointerIsOver && !model
           .bounds(context.frame.viewport, context.magnification)
-          .toScreenSpace(context.snapGrid)
+          .toScreenSpace(context.snapGrid * context.magnification.toInt)
           .contains(pt) =>
       Outcome(viewModel.copy(pointerIsOver = false))
         .addGlobalEvents(WindowEvent.PointerOut(model.id))
@@ -50,7 +50,7 @@ object WindowViewModel:
     case PointerEvent.Move(pt)
         if !viewModel.pointerIsOver && model
           .bounds(context.frame.viewport, context.magnification)
-          .toScreenSpace(context.snapGrid)
+          .toScreenSpace(context.snapGrid * context.magnification.toInt)
           .contains(pt) =>
       Outcome(viewModel.copy(pointerIsOver = true))
         .addGlobalEvents(WindowEvent.PointerOver(model.id))

--- a/indigo-extras/test/src/indigoextras/ui/components/ComponentGroupTests.scala
+++ b/indigo-extras/test/src/indigoextras/ui/components/ComponentGroupTests.scala
@@ -11,7 +11,7 @@ import indigoextras.ui.datatypes.UIContext
 class ComponentGroupTests extends munit.FunSuite:
 
   val ctx =
-    UIContext(Context.initial, 1)
+    UIContext(Context.initial, Magnification.x1)
 
   given Component[String, Unit] with
     def bounds(context: UIContext[Unit], model: String): Bounds =

--- a/indigo-extras/test/src/indigoextras/ui/components/datatypes/ContainerLikeFunctionsTests.scala
+++ b/indigo-extras/test/src/indigoextras/ui/components/datatypes/ContainerLikeFunctionsTests.scala
@@ -12,7 +12,7 @@ class ContainerLikeFunctionsTests extends munit.FunSuite:
     (_, _) => Outcome(Layer.empty)
 
   val ctx =
-    UIContext(Context.initial, 1)
+    UIContext(Context.initial, Magnification.x1)
 
   test("calculateNextOffset labels") {
 

--- a/indigo-extras/test/src/indigoextras/ui/datatypes/UIContextTests.scala
+++ b/indigo-extras/test/src/indigoextras/ui/datatypes/UIContextTests.scala
@@ -6,22 +6,46 @@ class UIContextTests extends munit.FunSuite {
 
   test("UIContext should correctly calculate the pointer coords") {
     val uiContext =
-      UIContext(Context.initial, 1)
+      UIContext(Context.initial, Magnification.x1)
         .withPointerCoords(Coords(10, 20))
 
     assertEquals(uiContext.pointerCoords, Coords(10, 20))
     assertEquals(uiContext.withSnapGrid(Size(2)).pointerCoords, Coords(5, 10))
     assertEquals(uiContext.withSnapGrid(Size(10)).pointerCoords, Coords(1, 2))
+  }
 
-    val ctxA =
-      UIContext(SubSystemContext.fromContext(Context.initial), Size(10), 2)
-        .withPointerCoords(Coords(10, 20))
-    val ctxB =
-      UIContext(Context.initial, 1)
-        .withSnapGrid(Size(10))
-        .withPointerCoords(Coords(10, 20))
+  test("pointerCoords divides screen-space pointer by magnification") {
+    // Pointer positions are screen-space pixels, so higher magnification means
+    // the pointer maps to a smaller grid coord - it must divide, not multiply.
+    val atX1 =
+      UIContext(Context.initial, Magnification.x1)
+        .withSnapGrid(Size(2))
+        .withPointerCoords(Coords(20, 40))
+    val atX2 =
+      UIContext(Context.initial, Magnification.x2)
+        .withSnapGrid(Size(2))
+        .withPointerCoords(Coords(20, 40))
 
-    assertEquals(ctxA.pointerCoords, ctxB.pointerCoords)
+    assertEquals(atX1.pointerCoords, Coords(10, 20))
+    assertEquals(atX2.pointerCoords, Coords(5, 10))
+  }
+
+  test("pointerCoords is the inverse of toScreenSpace") {
+    // A component drawn at grid coord `c` occupies screen pixels
+    // `c.toScreenSpace(snapGrid * magnification)`. A pointer over that top-left
+    // pixel must hit-test back to `c`.
+    val snapGrid      = Size(8)
+    val magnification = Magnification.x2
+    val coord         = Coords(3, 5)
+
+    val screenPos = coord.toScreenSpace(snapGrid * magnification.toInt)
+
+    val ctx =
+      UIContext(Context.initial, magnification)
+        .withSnapGrid(snapGrid)
+        .withPointerCoords(Coords(screenPos))
+
+    assertEquals(ctx.pointerCoords, coord)
   }
 
 }

--- a/indigo-extras/test/src/indigoextras/ui/datatypes/UIContextTests.scala
+++ b/indigo-extras/test/src/indigoextras/ui/datatypes/UIContextTests.scala
@@ -32,13 +32,13 @@ class UIContextTests extends munit.FunSuite {
 
   test("pointerCoords is the inverse of toScreenSpace") {
     // A component drawn at grid coord `c` occupies screen pixels
-    // `c.toScreenSpace(snapGrid * magnification)`. A pointer over that top-left
+    // `c.toScreenSpace(snapGrid, magnification)`. A pointer over that top-left
     // pixel must hit-test back to `c`.
     val snapGrid      = Size(8)
     val magnification = Magnification.x2
     val coord         = Coords(3, 5)
 
-    val screenPos = coord.toScreenSpace(snapGrid * magnification.toInt)
+    val screenPos = coord.toScreenSpace(snapGrid, magnification)
 
     val ctx =
       UIContext(Context.initial, magnification)

--- a/indigo-platform/test/src/indigo/shared/subsystems/PointsTrackerExample.scala
+++ b/indigo-platform/test/src/indigo/shared/subsystems/PointsTrackerExample.scala
@@ -3,7 +3,9 @@ package indigo.shared.subsystems
 import indigo.core.Outcome
 import indigo.core.assets.AssetName
 import indigo.core.datatypes.FontKey
+import indigo.core.datatypes.LayerKey
 import indigo.core.events.GlobalEvent
+import indigo.scenegraph.Layer
 import indigo.scenegraph.SceneUpdateFragment
 import indigo.scenegraph.Text
 import indigo.scenegraph.materials.Material
@@ -37,7 +39,9 @@ final case class PointsTrackerExample(num: Int, startingPoints: Int) extends Sub
 
   def present(context: SubSystemContext[Int], points: Int): Outcome[SceneUpdateFragment] =
     Outcome(
-      SceneUpdateFragment(Text(points.toString, 0, 0, FontKey(""), Material.Bitmap(AssetName("Testing"))))
+      SceneUpdateFragment(
+        LayerKey("test") -> Layer(Text(points.toString, 0, 0, FontKey(""), Material.Bitmap(AssetName("Testing"))))
+      )
     )
 }
 

--- a/indigo-render-pipeline/src/indigo/render/pipeline/datatypes/DisplayLayer.scala
+++ b/indigo-render-pipeline/src/indigo/render/pipeline/datatypes/DisplayLayer.scala
@@ -1,6 +1,5 @@
 package indigo.render.pipeline.datatypes
 
-import indigo.core.datatypes.LayerKey
 import indigo.scenegraph.Blend
 import indigo.scenegraph.Camera
 import indigo.shaders.ShaderId
@@ -8,7 +7,6 @@ import indigoengine.shared.collections.Batch
 import indigoengine.shared.datatypes.RGBA
 
 final case class DisplayLayer(
-    layerKey: Option[LayerKey],
     entities: Batch[DisplayEntity],
     lightsData: Batch[Float],
     bgColor: RGBA,

--- a/indigo-render-pipeline/src/indigo/render/pipeline/datatypes/ProcessedSceneData.scala
+++ b/indigo-render-pipeline/src/indigo/render/pipeline/datatypes/ProcessedSceneData.scala
@@ -1,6 +1,5 @@
 package indigo.render.pipeline.datatypes
 
-import indigo.render.pipeline.datatypes.DisplayLayer
 import indigo.render.pipeline.datatypes.DisplayObject
 import indigo.render.pipeline.datatypes.DisplayObjectUniformData
 import indigo.scenegraph.Camera

--- a/indigo-render-pipeline/src/indigo/render/pipeline/sceneprocessing/SceneProcessor.scala
+++ b/indigo-render-pipeline/src/indigo/render/pipeline/sceneprocessing/SceneProcessor.scala
@@ -130,7 +130,8 @@ object SceneProcessor:
 
     var i = 0
     while i < compacted.length do
-      val (maybeLayerKey, contentLayers) = compacted(i)
+      val (contentLayers, magnification) = compacted(i)
+      val magnificationOpt               = if magnification.toInt > 1 then Option(magnification.toInt) else None
 
       var j = 0
       while j < contentLayers.length do
@@ -148,11 +149,10 @@ object SceneProcessor:
 
         layerResults.append(
           DisplayLayer(
-            maybeLayerKey,
             conversionResults.displayEntities,
             BuildLightingData.makeLightsData(scene.lights ++ content.lights),
             blending.clearColor.getOrElse(RGBA.Zero),
-            content.magnification,
+            magnificationOpt,
             blending.entity,
             blending.layer,
             shaderData.shaderId,

--- a/indigo-render-pipeline/src/indigo/render/pipeline/sceneprocessing/utils/CompactLayers.scala
+++ b/indigo-render-pipeline/src/indigo/render/pipeline/sceneprocessing/utils/CompactLayers.scala
@@ -1,6 +1,6 @@
 package indigo.render.pipeline.sceneprocessing.utils
 
-import indigo.core.datatypes.LayerKey
+import indigo.core.render.Magnification
 import indigo.scenegraph.Layer
 import indigo.scenegraph.LayerEntry
 import indigoengine.shared.collections.Batch
@@ -10,28 +10,21 @@ import scala.annotation.tailrec
 object CompactLayers:
 
   /** Compact layers by squashing layers that have the same properties.
+    *
+    * Note: Layer Entries are already compacted because they get merged by key in an earler step.
     */
-  def compactLayers(layerEntries: Batch[LayerEntry]): Batch[(Option[LayerKey], Batch[Layer.Content])] =
-    layerEntries.map {
-      case LayerEntry.NoKey(layer: Layer.Content) =>
-        val ls = if layer.visible.getOrElse(true) then Batch(layer) else Batch.empty
+  def compactLayers(layerEntries: Batch[LayerEntry]): Batch[(Batch[Layer.Content], Magnification)] =
+    layerEntries.flatMap {
+      case LayerEntry(_, _, cfg) if cfg.isHidden =>
+        Batch.empty
 
-        (None, ls)
+      case LayerEntry(_, layer: Layer.Content, cfg) =>
+        Batch((Batch(layer), cfg.giveMagnification))
 
-      case LayerEntry.NoKey(stack: Layer.Stack) =>
+      case LayerEntry(_, stack: Layer.Stack, cfg) =>
         val ls = compactContentLayers(stack.toBatch)
-
-        (None, ls)
-
-      case LayerEntry.Keyed(key, layer: Layer.Content) =>
-        val ls = if layer.visible.getOrElse(true) then Batch(layer) else Batch.empty
-
-        (Option(key), ls)
-
-      case LayerEntry.Keyed(key, stack: Layer.Stack) =>
-        val ls = compactContentLayers(stack.toBatch)
-
-        (Option(key), ls)
+        if ls.isEmpty then Batch.empty
+        else Batch((ls, cfg.giveMagnification))
     }
 
   def compactContentLayers(contentLayers: Batch[Layer.Content]): Batch[Layer.Content] =
@@ -42,8 +35,7 @@ object CompactLayers:
         val head = remaining.head
         val tail = remaining.tail
 
-        if head.visible.exists(_ == false) then rec(tail, current, acc)
-        else if canCompactLayers(current, head) then
+        if canCompactLayers(current, head) then
           rec(
             tail,
             current.copy(nodes = current.nodes ++ head.nodes, cloneBlanks = current.cloneBlanks ++ head.cloneBlanks),
@@ -51,13 +43,10 @@ object CompactLayers:
           )
         else rec(tail, head, acc :+ current)
 
-    val contentLayersFirstIsVisible =
-      contentLayers.dropWhile(l => l.visible.exists(_ == false))
-
-    if contentLayersFirstIsVisible.length < 2 then contentLayersFirstIsVisible
+    if contentLayers.length < 2 then contentLayers
     else
-      val head = contentLayersFirstIsVisible.head
-      val tail = contentLayersFirstIsVisible.tail
+      val head = contentLayers.head
+      val tail = contentLayers.tail
 
       rec(tail, head, Batch.empty)
 
@@ -65,8 +54,4 @@ object CompactLayers:
     * we can compact them.
     */
   def canCompactLayers(a: Layer.Content, b: Layer.Content): Boolean =
-    a.lights == b.lights &&
-      a.magnification == b.magnification &&
-      a.visible == b.visible &&
-      a.blending == b.blending &&
-      a.camera == b.camera
+    a.lights == b.lights && a.blending == b.blending && a.camera == b.camera

--- a/indigo-render-pipeline/test/src/indigo/render/pipeline/sceneprocessing/SceneProcessorTests.scala
+++ b/indigo-render-pipeline/test/src/indigo/render/pipeline/sceneprocessing/SceneProcessorTests.scala
@@ -1,6 +1,7 @@
 package indigo.render.pipeline.sceneprocessing
 
 import indigo.core.assets.AssetName
+import indigo.core.datatypes.LayerKey
 import indigo.core.datatypes.Rectangle
 import indigo.core.datatypes.Size
 import indigo.core.datatypes.Vector2
@@ -47,7 +48,7 @@ class SceneProcessorTests extends munit.FunSuite {
 
   test("makeDisplayLayers - single layer with one graphic") {
     val graphic = Graphic(Size(200, 100), Material.Bitmap(AssetName("texture"))).withCrop(Rectangle(10, 20, 200, 100))
-    val scene   = SceneUpdateFragment(graphic)
+    val scene   = SceneUpdateFragment(LayerKey("test"))(graphic)
 
     val result = SceneProcessor.makeDisplayLayers(
       scene,
@@ -57,6 +58,7 @@ class SceneProcessorTests extends munit.FunSuite {
     )
 
     val (layers, cloneBlanks) = result
+
     assertEquals(layers.length, 1)
 
     val layer = layers(0)
@@ -69,8 +71,8 @@ class SceneProcessorTests extends munit.FunSuite {
     val graphic1 = Graphic(Size(50), Material.Bitmap(AssetName("texture"))).withCrop(Rectangle(0, 0, 50, 50))
     val graphic2 = Graphic(Size(50), Material.Bitmap(AssetName("texture"))).withCrop(Rectangle(100, 100, 50, 50))
     val scene = SceneUpdateFragment(
-      Layer(graphic1),
-      Layer(graphic2)
+      LayerKey("a") -> Layer(graphic1),
+      LayerKey("b") -> Layer(graphic2)
     )
 
     val result = SceneProcessor.makeDisplayLayers(
@@ -81,6 +83,7 @@ class SceneProcessorTests extends munit.FunSuite {
     )
 
     val (layers, _) = result
+
     assertEquals(layers.length, 2)
     assertEquals(layers(0).entities.length, 1)
     assertEquals(layers(1).entities.length, 1)
@@ -97,6 +100,7 @@ class SceneProcessorTests extends munit.FunSuite {
     )
 
     val (layers, _) = result
+
     assertEquals(layers.length, 0)
   }
 }

--- a/indigo-render-pipeline/test/src/indigo/render/pipeline/sceneprocessing/utils/CompactLayersTests.scala
+++ b/indigo-render-pipeline/test/src/indigo/render/pipeline/sceneprocessing/utils/CompactLayersTests.scala
@@ -4,6 +4,7 @@ import indigo.core.datatypes.Fill
 import indigo.core.datatypes.LayerKey
 import indigo.core.datatypes.Point
 import indigo.core.datatypes.Rectangle
+import indigo.core.render.Magnification
 import indigo.scenegraph.Camera
 import indigo.scenegraph.Layer
 import indigo.scenegraph.LayerEntry
@@ -31,7 +32,7 @@ class CompactLayersTests extends munit.FunSuite:
 
   lazy val uncompacted: Batch[LayerEntry] =
     Batch(
-      LayerEntry(Layer.empty),
+      LayerEntry(LayerKey("a"), Layer.empty).withMagnification(Magnification.x2),
       LayerEntry(LayerKey("b"), Layer.empty),
       LayerEntry(
         LayerKey("c"),
@@ -54,22 +55,49 @@ class CompactLayersTests extends munit.FunSuite:
       )
     )
 
-  lazy val compacted: Batch[(Option[LayerKey], Batch[Layer.Content])] =
+  lazy val compacted: Batch[(Batch[Layer.Content], Magnification)] =
     Batch(
-      (None, Batch(Layer.Content.empty)),
-      (Some(LayerKey("b")), Batch(Layer.Content.empty)),
+      (Batch(Layer.Content.empty), Magnification.x2),
+      (Batch(Layer.Content.empty), Magnification.default),
       (
-        Some(LayerKey("c")),
         Batch(
           Layer.Content(shape, shape)
-        )
+        ),
+        Magnification.default
       ),
       (
-        Some(LayerKey("d")),
         Batch(
           Layer.Content(shape).withCamera(Camera.Fixed(Point.zero)),
           Layer.Content(shape, shape).withCamera(Camera.Fixed(Point(10))),
           Layer.Content(shape)
-        )
+        ),
+        Magnification.default
       )
     )
+
+  test("magnification is applied once per LayerEntry, not compounded by nesting") {
+    val entry: LayerEntry =
+      LayerEntry(
+        LayerKey("deeply-nested"),
+        Layer.Stack(
+          Layer.Content(shape),
+          Layer.Stack(
+            Layer.Content(shape),
+            Layer.Stack(
+              Layer.Content(shape)
+            )
+          )
+        )
+      ).withMagnification(Magnification.x2)
+
+    val actual =
+      CompactLayers.compactLayers(Batch(entry))
+
+    // One group, carrying the entry's single x2 magnification - not x2 * x2 * x2.
+    assertEquals(actual.length, 1)
+
+    val (contents, magnification) = actual.head
+    assertEquals(magnification, Magnification.x2)
+    // All nested content layers share the same camera/blend/lights, so they compact to one.
+    assertEquals(contents, Batch(Layer.Content(shape, shape, shape)))
+  }

--- a/indigo-sandboxes/perf/src/com/example/perf/PerfGame.scala
+++ b/indigo-sandboxes/perf/src/com/example/perf/PerfGame.scala
@@ -36,7 +36,7 @@ final class PerfGame extends Game[Unit, Dude, DudeModel]:
         .withAssets(PerfAssets.assets)
         .withFonts(Fonts.fontInfo)
         .withSubSystems(
-          FPSCounter(Fonts.fontKey, PerfAssets.smallFontName)
+          FPSCounter(Fonts.fontKey, PerfAssets.smallFontName, LayerKey("fps"))
             .moveTo(10, 565)
         )
         .withShaders(

--- a/indigo-sandboxes/perf/src/com/example/perf/PerfView.scala
+++ b/indigo-sandboxes/perf/src/com/example/perf/PerfView.scala
@@ -12,8 +12,9 @@ object PerfView {
   def updateView(model: DudeModel): SceneUpdateFragment =
     SceneUpdateFragment.empty
       .addLayers(
-        Layer(gameLayer(model)),
-        Layer(uiLayer)
+        LayerKey("game") -> Layer(gameLayer(model)),
+        LayerKey("ui")   -> Layer(uiLayer),
+        LayerKey("fps")  -> Layer.empty
       )
       .addCloneBlanks(
         CloneBlank(cloneId, model.dude.sprite)

--- a/indigo-sandboxes/physics/src/example/IndigoPhysics.scala
+++ b/indigo-sandboxes/physics/src/example/IndigoPhysics.scala
@@ -22,7 +22,7 @@ final class IndigoPhysics extends Game[Unit, Unit, Model]:
       BootResult
         .noData(Config.config)
         .withSubSystems(
-          FPSCounter(PixelatedFont.fontKey, Assets.assets.generated.PixelatedFont)
+          FPSCounter(PixelatedFont.fontKey, Assets.assets.generated.PixelatedFont, LayerKey("fps"))
             .moveTo(Point(10))
         )
         .withAssets(Assets.assets.generated.assetSetRelative)

--- a/indigo-sandboxes/physics/src/example/LoadScene.scala
+++ b/indigo-sandboxes/physics/src/example/LoadScene.scala
@@ -45,7 +45,7 @@ object LoadScene extends Scene[Model]:
       context.services.bounds.find(tb).getOrElse(Rectangle(0, 0, 0, 0))
 
     Outcome(
-      SceneUpdateFragment(
+      SceneUpdateFragment(LayerKey("game"))(
         tb.moveTo(400 - (bounds.width / 2), 10)
       )
     )

--- a/indigo-sandboxes/physics/src/example/View.scala
+++ b/indigo-sandboxes/physics/src/example/View.scala
@@ -8,21 +8,25 @@ object View:
   def present(world: World[MyTag]): Outcome[SceneUpdateFragment] =
     Outcome(
       SceneUpdateFragment(
-        world.present {
-          case c: Collider.Circle[MyTag] =>
-            Shape.Circle(
-              c.bounds.position.toPoint,
-              c.bounds.radius.toInt,
-              Fill.Color(RGBA.White.withAlpha(0.2)),
-              Stroke(1, RGBA.White)
-            )
+        LayerKey("game") ->
+          Layer.Content(
+            world.present {
+              case c: Collider.Circle[MyTag] =>
+                Shape.Circle(
+                  c.bounds.position.toPoint,
+                  c.bounds.radius.toInt,
+                  Fill.Color(RGBA.White.withAlpha(0.2)),
+                  Stroke(1, RGBA.White)
+                )
 
-          case c: Collider.Box[MyTag] =>
-            Shape.Box(
-              c.bounds.toRectangle,
-              Fill.Color(RGBA.White.withAlpha(0.2)),
-              Stroke(1, RGBA.White)
-            )
-        }
+              case c: Collider.Box[MyTag] =>
+                Shape.Box(
+                  c.bounds.toRectangle,
+                  Fill.Color(RGBA.White.withAlpha(0.2)),
+                  Stroke(1, RGBA.White)
+                )
+            }
+          ),
+        LayerKey("fps") -> Layer.empty
       )
     )

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/SandboxGame.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/SandboxGame.scala
@@ -13,7 +13,7 @@ final class SandboxGame extends Game[SandboxBootData, SandboxStartupData, Sandbo
   val gameId: GameId = GameId("sandbox")
 
   def initialScene(bootData: SandboxBootData): Option[SceneName] =
-    Some(NineSliceScene.name)
+    Some(ComponentUIScene.name)
 
   def scenes(bootData: SandboxBootData): NonEmptyBatch[Scene[SandboxGameModel]] =
     ScenesList.scenes
@@ -36,9 +36,9 @@ final class SandboxGame extends Game[SandboxBootData, SandboxStartupData, Sandbo
       ).withSubSystems(
         FPSCounter[SandboxGameModel](
           Fonts.fontKey,
-          SandboxAssets.smallFontName
+          SandboxAssets.smallFontName,
+          Constants.LayerKeys.fps
         )
-          .withLayerKey(Constants.LayerKeys.fps)
           .placeAt { (context, bounds) =>
             Point(0, context.frame.viewport.height - bounds.height)
           }
@@ -124,10 +124,7 @@ final class SandboxGame extends Game[SandboxBootData, SandboxStartupData, Sandbo
         Constants.LayerKeys.background -> Layer.Stack.empty,
         Constants.LayerKeys.game       -> Layer.Stack.empty,
         Constants.LayerKeys.windows    -> Layer.Stack.empty,
-        Constants.LayerKeys.fps ->
-          Layer.empty
-            .withCamera(Camera.default)
-            .withMagnification(1)
+        Constants.LayerKeys.fps        -> Layer.empty.withCamera(Camera.default)
       )
     )
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/SandboxGame.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/SandboxGame.scala
@@ -13,7 +13,7 @@ final class SandboxGame extends Game[SandboxBootData, SandboxStartupData, Sandbo
   val gameId: GameId = GameId("sandbox")
 
   def initialScene(bootData: SandboxBootData): Option[SceneName] =
-    Some(ComponentUIScene.name)
+    Some(RefractionScene.name)
 
   def scenes(bootData: SandboxBootData): NonEmptyBatch[Scene[SandboxGameModel]] =
     ScenesList.scenes

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/SandboxView.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/SandboxView.scala
@@ -18,7 +18,7 @@ object SandboxView:
     }
 
     SceneUpdateFragment.empty
-      .addLayer(
+      .addLayers(
         LayerKey("game") ->
           Layer.Stack(
             Layer.Content(

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/BgAudioScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/BgAudioScene.scala
@@ -1,5 +1,6 @@
 package com.example.sandbox.scenes
 
+import com.example.sandbox.Constants
 import com.example.sandbox.Fonts
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGameModel
@@ -40,7 +41,7 @@ object BgAudioScene extends Scene[SandboxGameModel]:
   ): Outcome[SceneUpdateFragment] =
     Outcome(
       SceneUpdateFragment(
-        Layer(
+        Constants.LayerKeys.game -> Layer(
           Batch(
             Text("Music should be playing", Fonts.fontKey, textMaterial)
               .moveTo(10, 10)

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/BoundingCircleScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/BoundingCircleScene.scala
@@ -1,5 +1,6 @@
 package com.example.sandbox.scenes
 
+import com.example.sandbox.Constants
 import com.example.sandbox.SandboxGame
 import com.example.sandbox.SandboxGameModel
 import indigo.*
@@ -54,7 +55,7 @@ object BoundingCircleScene extends Scene[SandboxGameModel]:
 
     Outcome(
       SceneUpdateFragment.empty
-        .addLayer(
+        .addLayer(Constants.LayerKeys.game)(
           // Our bounding circle
           Shape.Circle(
             circle.position.toPoint,

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/BoundsScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/BoundsScene.scala
@@ -1,5 +1,6 @@
 package com.example.sandbox.scenes
 
+import com.example.sandbox.Constants
 import com.example.sandbox.Fonts
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGame
@@ -95,7 +96,7 @@ object BoundsScene extends Scene[SandboxGameModel]:
 
     Outcome(
       SceneUpdateFragment(
-        Layer(
+        Constants.LayerKeys.game -> Layer(
           Batch(
             graphic,
             Shape.Box(graphic.bounds, Fill.None, Stroke(1, RGBA.Green)),

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/BoxesScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/BoxesScene.scala
@@ -1,5 +1,6 @@
 package com.example.sandbox.scenes
 
+import com.example.sandbox.Constants
 import com.example.sandbox.SandboxGameModel
 import indigo.*
 import indigo.scenes.*
@@ -59,4 +60,8 @@ object BoxesScene extends Scene[SandboxGameModel]:
       context: SceneContext,
       model: SandboxGameModel
   ): Outcome[SceneUpdateFragment] =
-    Outcome(SceneUpdateFragment(Layer(shapes).withMagnification(1)))
+    Outcome(
+      SceneUpdateFragment(
+        Constants.LayerKeys.game -> Layer(shapes)
+      )
+    )

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/CameraScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/CameraScene.scala
@@ -1,5 +1,6 @@
 package com.example.sandbox.scenes
 
+import com.example.sandbox.Constants
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGame
 import com.example.sandbox.SandboxGameModel
@@ -42,17 +43,19 @@ object CameraScene extends Scene[SandboxGameModel] {
   ): Outcome[SceneUpdateFragment] =
     Outcome(
       SceneUpdateFragment(
-        Layer(
-          Graphic(
-            (SandboxGame.screenCenter * 4).toSize,
-            SandboxAssets.foliageMaterial
+        Constants.LayerKeys.game -> Layer.Stack(
+          Layer(
+            Graphic(
+              (SandboxGame.screenCenter * 4).toSize,
+              SandboxAssets.foliageMaterial
+            ),
+            Graphic(32, 32, Material.Bitmap(SandboxAssets.dots)).moveTo(-16, -16)
           ),
-          Graphic(32, 32, Material.Bitmap(SandboxAssets.dots)).moveTo(-16, -16)
-        ).withMagnification(1),
-        Layer(
-          Graphic(32, 32, Material.ImageEffects(SandboxAssets.dots).withAlpha(0.4))
-            .moveTo(SandboxGame.screenCenter - Point(16))
-        ).withCamera(Camera.default) // Override scene camera, so this layer doesn't move.
+          Layer(
+            Graphic(32, 32, Material.ImageEffects(SandboxAssets.dots).withAlpha(0.4))
+              .moveTo(SandboxGame.screenCenter - Point(16))
+          ).withCamera(Camera.default) // Override scene camera, so this layer doesn't move.
+        )
       ).modifyCamera {
         case c: Camera.Fixed =>
           c.toLookAt

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/CameraWithCloneTilesScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/CameraWithCloneTilesScene.scala
@@ -1,5 +1,6 @@
 package com.example.sandbox.scenes
 
+import com.example.sandbox.Constants
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGameModel
 import indigo.*
@@ -48,12 +49,14 @@ object CameraWithCloneTilesScene extends Scene[SandboxGameModel]:
   ): Outcome[SceneUpdateFragment] =
     Outcome(
       SceneUpdateFragment(
-        Layer
-          .Content(
-            CloneTiles(cloneId, crates)
-          )
-          .withCamera(Camera.LookAt(Point(96)))
-          .withMagnification(2)
-          .addCloneBlanks(cloneBlanks)
-      )
+        LayerEntry(
+          Constants.LayerKeys.game,
+          Layer
+            .Content(
+              CloneTiles(cloneId, crates)
+            )
+            .withCamera(Camera.LookAt(Point(96)))
+            .addCloneBlanks(cloneBlanks)
+        )
+      ).withMagnification(Magnification(2))
     )

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ClipScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ClipScene.scala
@@ -1,5 +1,6 @@
 package com.example.sandbox.scenes
 
+import com.example.sandbox.Constants
 import com.example.sandbox.Fonts
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGameModel
@@ -37,7 +38,7 @@ object ClipScene extends Scene[SandboxGameModel]:
   ): Outcome[SceneUpdateFragment] =
     Outcome(
       SceneUpdateFragment(
-        Layer(
+        Constants.LayerKeys.game -> Layer(
           (0 to 7).toBatch.flatMap { i =>
             model.dude.dude.clips
               .get(CycleLabel("walk right"))
@@ -120,7 +121,7 @@ object ClipScene extends Scene[SandboxGameModel]:
             makeDudeAnim(CycleLabel("walk left"), Point(232, 200), model.dude.dude.clips) ++
             makeDudeAnim(CycleLabel("walk up"), Point(200, 232), model.dude.dude.clips) ++
             makeDudeAnim(CycleLabel("walk down"), Point(232, 232), model.dude.dude.clips)
-        ).withMagnification(1)
+        )
       )
     )
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ComponentUIScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ComponentUIScene.scala
@@ -10,6 +10,8 @@ import indigoextras.ui.syntax.*
 
 object ComponentUIScene extends Scene[SandboxGameModel]:
 
+  val magnification = Magnification.x3
+
   type SceneModel = SandboxGameModel
 
   val name: SceneName =
@@ -37,7 +39,7 @@ object ComponentUIScene extends Scene[SandboxGameModel]:
 
     case e =>
       val ctx =
-        UIContext.fromContext(context.toContext, model.num, 1)
+        UIContext.fromContext(context.toContext, model.num, magnification)
 
       model.components.update(ctx)(e).map { cl =>
         model.copy(components = cl)
@@ -48,16 +50,19 @@ object ComponentUIScene extends Scene[SandboxGameModel]:
       model: SandboxGameModel
   ): Outcome[SceneUpdateFragment] =
     model.components
-      .present(UIContext.fromContext(context.toContext, model.num, 1))
+      .present(UIContext.fromContext(context.toContext, model.num, magnification))
       .map {
         case l: Layer.Stack =>
           SceneUpdateFragment(
-            Constants.LayerKeys.game -> Layer.Stack(
-              l.layers.map {
-                case l: Layer.Content => l.withMagnification(1)
-                case l                => l
-              }
-            )
+            LayerEntry(
+              Constants.LayerKeys.game,
+              Layer.Stack(
+                l.layers.map {
+                  case l: Layer.Content => l
+                  case l                => l
+                }
+              )
+            ).withMagnification(magnification)
           )
 
         case l: Layer.Content =>

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ComponentUIScene2.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ComponentUIScene2.scala
@@ -1,5 +1,6 @@
 package com.example.sandbox.scenes
 
+import com.example.sandbox.Constants
 import com.example.sandbox.Fonts
 import com.example.sandbox.Log
 import com.example.sandbox.SandboxAssets
@@ -41,7 +42,7 @@ object ComponentUIScene2 extends Scene[SandboxGameModel]:
       val ctx =
         UIContext(context.toContext)
           .withReferenceData(4)
-          .withMagnification(2)
+          .withMagnification(Magnification.x2)
 
       for {
         s <- model.scrollPane.update(ctx.moveParentTo(50, 10))(e)
@@ -57,6 +58,7 @@ object ComponentUIScene2 extends Scene[SandboxGameModel]:
       UIContext(context.toContext)
         .withReferenceData(4)
         .moveParentTo(50, 10)
+        .withMagnification(Magnification.x2)
 
     val scrollPaneBorder =
       Shape.Box(
@@ -68,8 +70,13 @@ object ComponentUIScene2 extends Scene[SandboxGameModel]:
     for {
       s <- model.scrollPane.present(ctx)
       b <- model.button.present(ctx.moveParentTo(10, 10))
-    } yield SceneUpdateFragment(b, s)
-      .addLayer(Layer(scrollPaneBorder))
+    } yield SceneUpdateFragment.empty
+      .addLayers(
+        Constants.LayerKeys.game -> b,
+        Constants.LayerKeys.game -> s,
+        Constants.LayerKeys.game -> Layer(scrollPaneBorder)
+      )
+      .withMagnification(Magnification.x2)
 
   object CustomComponents:
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ConfettiScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ConfettiScene.scala
@@ -1,5 +1,6 @@
 package com.example.sandbox.scenes
 
+import com.example.sandbox.Constants
 import com.example.sandbox.Fonts
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGame
@@ -77,13 +78,16 @@ object ConfettiScene extends Scene[SandboxGameModel]:
   ): Outcome[SceneUpdateFragment] =
     Outcome(
       SceneUpdateFragment(
-        Layer(
-          model.particles.map(particlesToCloneTiles)
-        ).withMagnification(1),
-        Layer(
-          count.withText(s"count: ${model.particles.length * spawnCount}")
-        ).withMagnification(1)
+        Constants.LayerKeys.game -> Layer.Stack(
+          Layer(
+            model.particles.map(particlesToCloneTiles)
+          ),
+          Layer(
+            count.withText(s"count: ${model.particles.length * spawnCount}")
+          )
+        )
       ).addCloneBlanks(cloneBlanks)
+        .withMagnification(Magnification(2))
     )
 
 final case class ConfettiModel(color: Int, particles: Batch[Batch[Particle]]):

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/CratesScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/CratesScene.scala
@@ -1,5 +1,6 @@
 package com.example.sandbox.scenes
 
+import com.example.sandbox.Constants
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGameModel
 import indigo.*
@@ -50,7 +51,7 @@ object CratesScene extends Scene[SandboxGameModel]:
   ): Outcome[SceneUpdateFragment] =
     Outcome(
       SceneUpdateFragment(
-        Layer(
+        Constants.LayerKeys.game -> Layer(
           graphic.moveTo(16, 16),
           CloneTiles(
             cloneId,

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/LegacyEffectsScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/LegacyEffectsScene.scala
@@ -1,5 +1,6 @@
 package com.example.sandbox.scenes
 
+import com.example.sandbox.Constants
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGame
 import com.example.sandbox.SandboxGameModel
@@ -43,7 +44,7 @@ object LegacyEffectsScene extends Scene[SandboxGameModel] {
     val viewCenter: Point = SandboxGame.screenCenter + Point(0, -25)
 
     Outcome(
-      SceneUpdateFragment(
+      SceneUpdateFragment(Constants.LayerKeys.game)(
         graphic // tint - identical to ImageEffects material
           .moveTo(viewCenter)
           .moveBy(0, -40)

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/LightsScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/LightsScene.scala
@@ -1,5 +1,6 @@
 package com.example.sandbox.scenes
 
+import com.example.sandbox.Constants
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGameModel
 import indigo.*
@@ -62,8 +63,8 @@ object LightsScene extends Scene[SandboxGameModel] {
       Point(550, 400) / 2 / 2
 
     Outcome(
-      SceneUpdateFragment(graphic, graphic2, shape)
-        .withMagnification(2)
+      SceneUpdateFragment(Constants.LayerKeys.game)(graphic, graphic2, shape)
+        .withMagnification(Magnification(2))
         .withLights(
           AmbientLight(RGBA.Blue.withAlpha(0.1)),
           DirectionLight(RGBA.Cyan.withAmount(0.1), RGBA.Cyan, Radians.zero),

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/LineReflectionScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/LineReflectionScene.scala
@@ -1,5 +1,6 @@
 package com.example.sandbox.scenes
 
+import com.example.sandbox.Constants
 import com.example.sandbox.Fonts
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGame
@@ -122,7 +123,7 @@ object LineReflectionScene extends Scene[SandboxGameModel]:
 
     Outcome(
       SceneUpdateFragment.empty
-        .addLayer(
+        .addLayer(Constants.LayerKeys.game)(
           Batch(
             // Surface
             Shape.Line(
@@ -145,13 +146,13 @@ object LineReflectionScene extends Scene[SandboxGameModel]:
           ) ++
             reflection
         )
-        .addLayer(
+        .addLayer(Constants.LayerKeys.game)(
           Layer(text)
-            .withMagnification(1)
             .withCamera(
               Camera
                 .Fixed(SandboxGame.screenCenter * 2)
                 .withZoom(Zoom.x05)
             )
         )
+        .withMagnification(Magnification(2))
     )

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/MagnificationScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/MagnificationScene.scala
@@ -1,0 +1,65 @@
+package com.example.sandbox.scenes
+
+import com.example.sandbox.SandboxAssets
+import com.example.sandbox.SandboxGameModel
+import indigo.*
+import indigo.scenes.*
+
+object MagnificationScene extends Scene[SandboxGameModel] {
+
+  type SceneModel = SandboxGameModel
+
+  def eventFilters: EventFilters =
+    EventFilters.Restricted
+
+  def modelLens: Lens[SandboxGameModel, SandboxGameModel] =
+    Lens.keepOriginal
+
+  def name: SceneName =
+    SceneName("magnification scene")
+
+  def subSystems: Set[SubSystem[SandboxGameModel]] =
+    Set()
+
+  def updateModel(
+      context: SceneContext,
+      model: SandboxGameModel
+  ): GlobalEvent => Outcome[SandboxGameModel] =
+    _ => Outcome(model)
+
+  def present(
+      context: SceneContext,
+      model: SandboxGameModel
+  ): Outcome[SceneUpdateFragment] = {
+    val graphic =
+      Graphic(64, 64, Material.Bitmap(SandboxAssets.cratesDiffuseName))
+
+    Outcome(
+      SceneUpdateFragment.empty
+        .addLayers(
+          LayerEntry(LayerKey("a"), Layer.Content(graphic.moveTo(10, 10)), Magnification.x1),
+          LayerEntry(
+            LayerKey("b"),
+            Layer.Content(graphic.moveTo(10 + 60, 10)),
+            Magnification.x2
+          ),
+          LayerEntry(
+            LayerKey("c"),
+            Layer.Stack(
+              Layer.Stack(
+                Layer.Content(graphic.moveTo(10, 10 + 60))
+              )
+            ),
+            Magnification.x2
+          ),
+          LayerEntry(
+            LayerKey("d"),
+            Layer.Content(graphic.moveTo(10 + 30, 10 + 30)),
+            // Layer.Content(graphic),
+            Magnification.x4
+          )
+        )
+    )
+  }
+
+}

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ManyEventHandlers.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ManyEventHandlers.scala
@@ -1,5 +1,6 @@
 package com.example.sandbox.scenes
 
+import com.example.sandbox.Constants
 import com.example.sandbox.SandboxGameModel
 import indigo.*
 import indigo.scenes.*
@@ -60,8 +61,8 @@ object ManyEventHandlers extends Scene[SandboxGameModel]:
   ): Outcome[SceneUpdateFragment] =
     Outcome(
       SceneUpdateFragment(
-        Layer(
+        Constants.LayerKeys.game -> Layer(
           sprites(model.dude.dude.sprite.withRef(Point.zero).moveTo(Point.zero))
-        ).withMagnification(1)
+        )
       )
     )

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/MeshScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/MeshScene.scala
@@ -1,5 +1,6 @@
 package com.example.sandbox.scenes
 
+import com.example.sandbox.Constants
 import com.example.sandbox.SandboxGameModel
 import indigo.*
 import indigo.scenes.*
@@ -33,7 +34,7 @@ object MeshScene extends Scene[SandboxGameModel]:
   ): Outcome[SceneUpdateFragment] =
 
     Outcome(
-      SceneUpdateFragment(
+      SceneUpdateFragment(Constants.LayerKeys.game)(
         drawMesh(
           model.meshData.points,
           model.meshData.superTriangle,

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/MultiPointScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/MultiPointScene.scala
@@ -1,5 +1,6 @@
 package com.example.sandbox.scenes
 
+import com.example.sandbox.Constants
 import com.example.sandbox.Fonts
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGameModel
@@ -104,7 +105,7 @@ object MultiPointScene extends Scene[SandboxGameModel]:
   ): Outcome[SceneUpdateFragment] =
     Outcome(
       SceneUpdateFragment(
-        Layer(
+        Constants.LayerKeys.game -> Layer(
           // Pen data
           Text("Pen", Fonts.fontKey, textMaterial).moveTo(10, 10),
           Text(s"${model.pen.pos.x},${model.pen.pos.y}", Fonts.fontKey, textMaterial).moveTo(10, 30),
@@ -155,7 +156,7 @@ object MultiPointScene extends Scene[SandboxGameModel]:
             textMaterial
           ).moveTo(10, 380),
           Text(s"Is ${if model.pointer.isDown then "Down" else "Up"}", Fonts.fontKey, textMaterial).moveTo(10, 400)
-        ).withMagnification(1)
+        )
       )
     )
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/MutantsScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/MutantsScene.scala
@@ -1,5 +1,6 @@
 package com.example.sandbox.scenes
 
+import com.example.sandbox.Constants
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGame
 import com.example.sandbox.SandboxGameModel
@@ -75,7 +76,7 @@ object MutantsScene extends Scene[SandboxGameModel]:
       model: SandboxGameModel
   ): Outcome[SceneUpdateFragment] =
     Outcome(
-      SceneUpdateFragment(
+      SceneUpdateFragment(Constants.LayerKeys.game)(
         Mutants(cloneId, data)
         // Mutants(cloneId, dataMax)
         // gfx

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/NineSliceScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/NineSliceScene.scala
@@ -100,8 +100,9 @@ object NineSliceScene extends Scene[SandboxGameModel] {
                   (0 until 4).toBatch.map(col => Point(col * 100, 300)),
                   true
                 )
-            ).withMagnificationForAll(2)
+            )
         )
+        .withMagnification(Magnification(4))
     )
   }
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/NineSliceScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/NineSliceScene.scala
@@ -102,7 +102,6 @@ object NineSliceScene extends Scene[SandboxGameModel] {
                 )
             )
         )
-        .withMagnification(Magnification(4))
     )
   }
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/OriginalScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/OriginalScene.scala
@@ -1,5 +1,6 @@
 package com.example.sandbox.scenes
 
+import com.example.sandbox.Constants
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGameModel
 import com.example.sandbox.SandboxView
@@ -38,14 +39,14 @@ object OriginalScene extends Scene[SandboxGameModel] {
 
     Outcome(
       scene
-        .addLayer(
-          LayerKey("bg") ->
+        .addLayers(
+          Constants.LayerKeys.background ->
             Layer(
               BlankEntity(0, 0, 228 * 3, 140 * 3, ShaderData(Shaders.seaId))
-            ).withMagnification(1)
+            )
         )
-        .addLayer(
-          LayerKey("game") ->
+        .addLayers(
+          Constants.LayerKeys.game ->
             Layer(
               Batch(
                 Graphic(120, 10, 32, 32, SandboxAssets.dotsMaterial),

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/PathFindingScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/PathFindingScene.scala
@@ -1,6 +1,7 @@
 package com.example.sandbox.scenes
 
 import com.example.sandbox.*
+import com.example.sandbox.Constants
 import indigo.*
 import indigo.scenes.*
 import indigoextras.pathfinding.*
@@ -75,7 +76,7 @@ object PathFindingScene extends Scene[SandboxGameModel]:
     val path = PathFinder.findPath(start, end, pathBuilder).getOrElse(Batch.empty) // if no path found, return empty
 
     Outcome(
-      SceneUpdateFragment(
+      SceneUpdateFragment(Constants.LayerKeys.game)(
         Batch.combineAll(
           (for {
             y <- 0 until gridSize

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/PointersScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/PointersScene.scala
@@ -1,5 +1,6 @@
 package com.example.sandbox.scenes
 
+import com.example.sandbox.Constants
 import com.example.sandbox.Fonts
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGameModel
@@ -56,7 +57,7 @@ object PointersScene extends Scene[SandboxGameModel]:
   ): Outcome[SceneUpdateFragment] =
     Outcome(
       SceneUpdateFragment(
-        Layer(
+        Constants.LayerKeys.game -> Layer(
           Batch(
             Text("Touch the screen", Fonts.fontKey, textMaterial)
               .moveTo(10, 10)

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/RefractionScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/RefractionScene.scala
@@ -83,7 +83,7 @@ object RefractionScene extends Scene[SandboxGameModel] {
             )
           )
         )
-        .withMagnification(Magnification(2))
+        .withMagnification(Magnification.x2)
     )
   }
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/RefractionScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/RefractionScene.scala
@@ -1,5 +1,6 @@
 package com.example.sandbox.scenes
 
+import com.example.sandbox.Constants
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGame
 import com.example.sandbox.SandboxGameModel
@@ -60,17 +61,17 @@ object RefractionScene extends Scene[SandboxGameModel] {
     Outcome(
       SceneUpdateFragment.empty
         .addLayers(
-          Layer(
+          Constants.LayerKeys.game -> Layer(
             background,
             graphic.moveTo(viewCenter),
             graphic.moveTo(viewCenter).moveBy(-60, 0).withMaterial(SandboxAssets.junctionBoxMaterial),
             graphic.moveTo(viewCenter).moveBy(-30, 0).withMaterial(SandboxAssets.junctionBoxMaterial),
             graphic.moveTo(viewCenter).moveBy(30, 0).withMaterial(SandboxAssets.junctionBoxMaterial),
             graphic.moveTo(viewCenter).moveBy(60, 0).withMaterial(SandboxAssets.junctionBoxMaterial)
-          ).withMagnification(2),
-          Layer(imageLight)
+          ),
+          Constants.LayerKeys.game -> Layer(imageLight)
             .withBlending(Blending.Lighting(RGBA(0.2, 0.5, 0.3, 0.5))),
-          Layer(
+          Constants.LayerKeys.game -> Layer(
             distortion.moveTo(viewCenter + Point(50, 0)),
             sliding.affectTime(0.3).at(context.frame.time.running)
           ).withBlending(
@@ -82,6 +83,7 @@ object RefractionScene extends Scene[SandboxGameModel] {
             )
           )
         )
+        .withMagnification(Magnification(2))
     )
   }
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ScenesList.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ScenesList.scala
@@ -43,5 +43,6 @@ object ScenesList:
       PerformerPhysicsScene,
       ViewportResizeScene,
       MultiPointScene,
-      BgAudioScene
+      BgAudioScene,
+      MagnificationScene
     )

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/SfxScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/SfxScene.scala
@@ -39,7 +39,7 @@ object SfxScene extends Scene[SandboxGameModel]:
 
     case e =>
       val ctx =
-        UIContext(context.toContext, 1)
+        UIContext(context.toContext, Magnification.x1)
 
       model.sfxComponents.update(ctx)(e).map { cl =>
         model.copy(sfxComponents = cl)
@@ -50,13 +50,13 @@ object SfxScene extends Scene[SandboxGameModel]:
       model: SandboxGameModel
   ): Outcome[SceneUpdateFragment] =
     model.sfxComponents
-      .present(UIContext(context.toContext, 1))
+      .present(UIContext(context.toContext, Magnification.x1))
       .map {
         case l: Layer.Stack =>
           SceneUpdateFragment(
             Constants.LayerKeys.game -> Layer.Stack(
               l.layers.map {
-                case l: Layer.Content => l.withMagnification(1)
+                case l: Layer.Content => l
                 case l                => l
               }
             )

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ShapesScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ShapesScene.scala
@@ -1,5 +1,6 @@
 package com.example.sandbox.scenes
 
+import com.example.sandbox.Constants
 import com.example.sandbox.SandboxGameModel
 import indigo.*
 import indigo.scenes.*
@@ -78,7 +79,7 @@ object ShapesScene extends Scene[SandboxGameModel]:
 
     Outcome(
       SceneUpdateFragment.empty
-        .addLayer(
+        .addLayer(Constants.LayerKeys.game)(
           Shape.Circle(
             circlePosition,
             20,

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/TextScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/TextScene.scala
@@ -1,5 +1,6 @@
 package com.example.sandbox.scenes
 
+import com.example.sandbox.Constants
 import com.example.sandbox.Fonts
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGameModel
@@ -37,14 +38,14 @@ object TextScene extends Scene[SandboxGameModel] {
   ): Outcome[SceneUpdateFragment] =
     Outcome(
       SceneUpdateFragment(
-        Layer(
+        Constants.LayerKeys.game -> Layer(
           Batch(
             Text("The quick brown fox\njumps over the\nlazy dog.", Fonts.fontKey, textMaterial)
               .moveTo(10, 10),
             Text("The quick brown fox\njumps over the\nlazy dog.", TestFont.fontKey, SandboxAssets.testFontMaterial)
               .moveTo(10, 100)
           )
-        ).withMagnification(1)
+        )
       )
     )
 

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/TextureTileScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/TextureTileScene.scala
@@ -1,5 +1,6 @@
 package com.example.sandbox.scenes
 
+import com.example.sandbox.Constants
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGame
 import com.example.sandbox.SandboxGameModel
@@ -40,7 +41,7 @@ object TextureTileScene extends Scene[SandboxGameModel] {
     Outcome(
       SceneUpdateFragment.empty
         .addLayers(
-          Layer(
+          Constants.LayerKeys.game -> Layer(
             Graphic(32, 32, Material.ImageEffects(SandboxAssets.dots))
               .withRef(16, 16)
               .moveTo(SandboxGame.screenCenter)

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/TimelineScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/TimelineScene.scala
@@ -1,5 +1,6 @@
 package com.example.sandbox.scenes
 
+import com.example.sandbox.Constants
 import com.example.sandbox.Dude
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGameModel
@@ -93,7 +94,7 @@ object TimelineScene extends Scene[SandboxGameModel]:
     val dude = model.sprite.changeCycle(CycleLabel("walk right")).moveTo(32, 32)
 
     Outcome(
-      SceneUpdateFragment(
+      SceneUpdateFragment(Constants.LayerKeys.game)(
         tl(2.seconds).atOrLast(context.frame.time.running)(crate).toBatch ++
           spriteTimeline
             .at(context.frame.time.running)(dude)

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/UltravioletScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/UltravioletScene.scala
@@ -1,5 +1,6 @@
 package com.example.sandbox.scenes
 
+import com.example.sandbox.Constants
 import com.example.sandbox.SandboxGameModel
 import indigo.*
 import indigo.scenes.*
@@ -35,7 +36,7 @@ object UltravioletScene extends Scene[SandboxGameModel] {
   ): Outcome[SceneUpdateFragment] =
     Outcome(
       SceneUpdateFragment.empty
-        .addLayer(
+        .addLayer(Constants.LayerKeys.game)(
           Layer(
             BlankEntity(10, 10, 150, 150, ShaderData(UVShaders.voronoiId)),
             BlankEntity(140, 50, 32, 32, ShaderData(UVShaders.circleId))

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ViewportResizeScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ViewportResizeScene.scala
@@ -1,5 +1,6 @@
 package com.example.sandbox.scenes
 
+import com.example.sandbox.Constants
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGameModel
 import indigo.*
@@ -34,7 +35,7 @@ object ViewportResizeScene extends Scene[SandboxGameModel] {
     Outcome(
       SceneUpdateFragment.empty
         .addLayers(
-          Layer(
+          Constants.LayerKeys.game -> Layer(
             Graphic(
               model.viewportSize,
               Material.Bitmap(SandboxAssets.nineSlice).nineSlice(Rectangle(16, 16, 32, 32))

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/WaypointScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/WaypointScene.scala
@@ -1,5 +1,6 @@
 package com.example.sandbox.scenes
 
+import com.example.sandbox.Constants
 import com.example.sandbox.SandboxAssets
 import com.example.sandbox.SandboxGameModel
 import indigo.*
@@ -243,7 +244,7 @@ object WaypointScene extends Scene[SandboxGameModel]:
       )
 
     Outcome(
-      SceneUpdateFragment(
+      SceneUpdateFragment(Constants.LayerKeys.game)(
         pentagramPathGraphics ++
           decagonPathGraphics ++
           waypointGraphics ++

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/WindowsScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/WindowsScene.scala
@@ -25,7 +25,7 @@ object WindowsScene extends Scene[SandboxGameModel]:
     Set(
       WindowManager[Unit, SandboxGameModel, Int](
         id = SubSystemId("window-manager"),
-        magnification = 2,
+        magnification = Magnification.x2,
         snapGrid = Size.one,
         extractReference = _.num,
         startUpData = (),

--- a/indigo-sandboxes/sandbox/src-native/main/scala/com/example/sandbox/scenes/ShapesScene.scala
+++ b/indigo-sandboxes/sandbox/src-native/main/scala/com/example/sandbox/scenes/ShapesScene.scala
@@ -78,7 +78,7 @@ object ShapesScene extends Scene[SandboxGameModel]:
 
     Outcome(
       SceneUpdateFragment.empty
-        .addLayer(
+        .addLayer(LayerKey("game"))(
           Shape.Circle(
             circlePosition,
             20,

--- a/indigo-sandboxes/tyrian-sandbox/src/example/game/GameScene.scala
+++ b/indigo-sandboxes/tyrian-sandbox/src/example/game/GameScene.scala
@@ -34,7 +34,7 @@ final case class GameScene(clockwise: Boolean) extends Scene[Unit]:
       else Radians(-Radians.fromSeconds(context.frame.time.running * 0.25).toDouble)
 
     Outcome(
-      SceneUpdateFragment(
+      SceneUpdateFragment(LayerKey("game"))(
         Shape
           .Box(
             Rectangle(0, 0, 60, 60),

--- a/indigo-scenegraph/src/indigo/scenegraph/Layer.scala
+++ b/indigo-scenegraph/src/indigo/scenegraph/Layer.scala
@@ -35,12 +35,10 @@ enum Layer derives CanEqual:
     *
     * @param nodes
     *   Nodes to render in this layer.
+    * @param cloneBlanks
+    *   A collection of 'template' nodes or 'clone blanks' to be used in the cloning process.
     * @param lights
     *   Layer level dynamic lights
-    * @param magnification
-    *   Optionally set the magnification, defaults to scene magnification.
-    * @param visible
-    *   Optionally set the visiblity, defaults to visible
     * @param blending
     *   Optionally describes how to blend this layer onto the one below, by default, simply overlays one onto the other.
     * @param camera
@@ -48,20 +46,11 @@ enum Layer derives CanEqual:
     */
   case Content(
       nodes: Batch[SceneNode],
-      lights: Batch[Light],
-      magnification: Option[Int],
-      visible: Option[Boolean],
-      blending: Option[Blending],
       cloneBlanks: Batch[CloneBlank],
-      camera: Option[Camera]
+      lights: Batch[Light],
+      blending: Option[Blending], // TODO: Can we make this non-optional?
+      camera: Option[Camera]      // TODO: Can we make this non-optional?
   )
-
-  /** Apply a magnification to this layer and all it's child layers
-    *
-    * @param level
-    */
-  def withMagnificationForAll(level: Int): Layer =
-    this.modify { case l: Layer.Content => l.withMagnification(level) }
 
   def toBatch: Batch[Layer.Content] =
     @tailrec
@@ -122,16 +111,16 @@ object Layer:
   object Content:
 
     val empty: Layer.Content =
-      Layer.Content(Batch.empty, Batch.empty, None, None, None, Batch.empty, None)
+      Layer.Content(Batch.empty, Batch.empty, Batch.empty, None, None)
 
     def apply(nodes: SceneNode*): Layer.Content =
-      Layer.Content(Batch.fromSeq(nodes), Batch.empty, None, None, None, Batch.empty, None)
+      Layer.Content(Batch.fromSeq(nodes), Batch.empty, Batch.empty, None, None)
 
     def apply(nodes: Batch[SceneNode]): Layer.Content =
-      Layer.Content(nodes, Batch.empty, None, None, None, Batch.empty, None)
+      Layer.Content(nodes, Batch.empty, Batch.empty, None, None)
 
     def apply(maybeNode: Option[SceneNode]): Layer.Content =
-      Layer.Content(Batch.fromOption(maybeNode), Batch.empty, None, None, None, Batch.empty, None)
+      Layer.Content(Batch.fromOption(maybeNode), Batch.empty, Batch.empty, None, None)
 
   extension (l: Layer)
     /** Modifies this layer, and then in the case of Layer.Stack subsequently modifies all child layers using the
@@ -167,11 +156,9 @@ object Layer:
   def mergeContentLayers(a: Layer.Content, b: Layer.Content): Layer.Content =
     a.copy(
       a.nodes ++ b.nodes,
-      a.lights ++ b.lights,
-      a.magnification.orElse(b.magnification),
-      a.visible.orElse(b.visible),
-      a.blending.orElse(b.blending),
       a.cloneBlanks ++ b.cloneBlanks,
+      a.lights ++ b.lights,
+      a.blending.orElse(b.blending),
       a.camera.orElse(b.camera)
     )
 
@@ -205,15 +192,6 @@ object Layer:
     def addLights(newLights: Batch[Light]): Layer.Content =
       withLights(lc.lights ++ newLights)
 
-    def withVisibility(isVisible: Boolean): Layer.Content =
-      lc.copy(visible = Option(isVisible))
-
-    def show: Layer.Content =
-      withVisibility(true)
-
-    def hide: Layer.Content =
-      withVisibility(false)
-
     def withBlending(newBlending: Blending): Layer.Content =
       lc.copy(blending = Option(newBlending))
     def withEntityBlend(newBlend: Blend): Layer.Content =
@@ -241,13 +219,6 @@ object Layer:
       lc.copy(cloneBlanks = lc.cloneBlanks ++ blanks)
     def addCloneBlanks(blanks: CloneBlank*): Layer.Content =
       lc.addCloneBlanks(Batch.fromSeq(blanks))
-
-    /** Apply a magnification to this content layer
-      *
-      * @param level
-      */
-    def withMagnification(level: Int): Layer.Content =
-      lc.copy(magnification = Option(Math.max(1, Math.min(256, level))))
 
     def ::(stack: Layer.Stack): Layer.Stack =
       stack.prepend(lc)

--- a/indigo-scenegraph/src/indigo/scenegraph/LayerEntry.scala
+++ b/indigo-scenegraph/src/indigo/scenegraph/LayerEntry.scala
@@ -24,7 +24,7 @@ final case class LayerEntry(key: LayerKey, layer: Layer, config: LayerEntry.Conf
   def withMagnification(newMagnification: Magnification): LayerEntry =
     withConfig(config.withMagnification(newMagnification))
   def clearMagnification: LayerEntry =
-    withMagnification(Magnification.x1)
+    withConfig(config.clearMagnification)
 
   def withVisibility(isVisible: Boolean): LayerEntry =
     withConfig(config.withVisibility(isVisible))

--- a/indigo-scenegraph/src/indigo/scenegraph/LayerEntry.scala
+++ b/indigo-scenegraph/src/indigo/scenegraph/LayerEntry.scala
@@ -1,63 +1,89 @@
 package indigo.scenegraph
 
 import indigo.core.datatypes.LayerKey
+import indigo.core.render.Magnification
 import indigoengine.shared.collections.Batch
 
-/** Layer entries are holders for Layers, that can either be tagged or untagged. If a layer entry is tagged with a
-  * `LayerKey`, then if two SceneUpdateFragements are merged together, two entries will the same layerKey will be
-  * combined at the depth of the original.
+/** Layer entries are holders for Layers. Layer entries are tagged with a `LayerKey`, the purpose of which is that when
+  * two SceneUpdateFragements are merged together, two entries will the same layerKey will be combined at the depth of
+  * the original. Layer entries also hold the configuration for the layers it looks after.
   */
-enum LayerEntry:
-  def layer: Layer
-
-  case NoKey(layer: Layer)
-  case Keyed(layerKey: LayerKey, layer: Layer)
+final case class LayerEntry(key: LayerKey, layer: Layer, config: LayerEntry.Config):
+  def withKey(newKey: LayerKey): LayerEntry =
+    this.copy(key = newKey)
 
   def hasKey(layerKey: LayerKey): Boolean =
-    this match
-      case _: LayerEntry.NoKey => false
-      case l: LayerEntry.Keyed => l.layerKey == layerKey
-
-  def giveKey: Option[LayerKey] =
-    this match
-      case NoKey(_)           => None
-      case Keyed(layerKey, _) => Option(layerKey)
-
-  def withKey(newKey: LayerKey): LayerEntry =
-    LayerEntry.Keyed(newKey, this.layer)
+    key == layerKey
 
   def withLayer(newLayer: Layer): LayerEntry =
-    this match
-      case l: LayerEntry.NoKey => l.copy(layer = newLayer)
-      case l: LayerEntry.Keyed => l.copy(layer = newLayer)
+    this.copy(layer = newLayer)
+
+  def withConfig(newConfig: LayerEntry.Config): LayerEntry =
+    this.copy(config = newConfig)
+
+  def withMagnification(newMagnification: Magnification): LayerEntry =
+    withConfig(config.withMagnification(newMagnification))
+  def clearMagnification: LayerEntry =
+    withMagnification(Magnification.x1)
+
+  def withVisibility(isVisible: Boolean): LayerEntry =
+    withConfig(config.withVisibility(isVisible))
+  def show: LayerEntry =
+    withVisibility(true)
+  def hide: LayerEntry =
+    withVisibility(false)
 
   def modify(f: LayerEntry => LayerEntry): LayerEntry =
     f(this)
   def modifyLayer(pf: PartialFunction[Layer, Layer]): LayerEntry =
-    this match
-      case l: LayerEntry.NoKey => l.copy(layer = layer.modify(pf))
-      case l: LayerEntry.Keyed => l.copy(layer = layer.modify(pf))
-
-  /** Apply a magnification to this layer entry's layer, and all it's child layers.
-    *
-    * @param level
-    */
-  def withMagnificationForAll(level: Int): LayerEntry =
-    this.modifyLayer(_.withMagnificationForAll(level))
+    this.copy(layer = layer.modify(pf))
 
   def toBatch: Batch[Layer.Content] =
     layer.toBatch
 
 object LayerEntry:
 
-  def apply(layerKey: LayerKey, layer: Layer): LayerEntry =
-    LayerEntry.Keyed(layerKey, layer)
+  def apply(key: LayerKey, layer: Layer): LayerEntry =
+    LayerEntry(key, layer, Config.default)
 
-  def apply(maybeKey: Option[LayerKey], layer: Layer): LayerEntry =
-    maybeKey.fold(LayerEntry(layer))(layerKey => LayerEntry(layerKey, layer))
+  def apply(key: LayerKey, layer: Layer, magnification: Magnification): LayerEntry =
+    LayerEntry(key, layer, Config.default.withMagnification(magnification))
 
-  def apply(keyAndLayer: (LayerKey, Layer)): LayerEntry =
-    LayerEntry.Keyed(keyAndLayer._1, keyAndLayer._2)
+  /** Contains the configuration for this layer entry.
+    *
+    * Fields are optional to support left-bias monoidal merging.
+    */
+  final case class Config(
+      magnification: Option[Magnification],
+      visible: Option[Boolean]
+  ):
 
-  def apply(layer: Layer): LayerEntry =
-    LayerEntry.NoKey(layer)
+    def |+|(other: Config): Config =
+      Config(
+        this.magnification.orElse(other.magnification),
+        this.visible.orElse(other.visible)
+      )
+
+    def withMagnification(newMagnification: Magnification): Config =
+      this.copy(magnification = Some(newMagnification))
+    def clearMagnification: Config =
+      this.copy(magnification = None)
+
+    def giveMagnification: Magnification =
+      magnification.getOrElse(Magnification.x1)
+
+    def withVisibility(isVisible: Boolean): Config =
+      this.copy(visible = Some(isVisible))
+    def show: Config =
+      withVisibility(true)
+    def hide: Config =
+      withVisibility(false)
+
+    def isVisible: Boolean =
+      visible.getOrElse(true)
+    def isHidden: Boolean =
+      !isVisible
+
+  object Config:
+    val default: Config =
+      Config(None, None)

--- a/indigo-scenegraph/src/indigo/scenegraph/SceneUpdateFragment.scala
+++ b/indigo-scenegraph/src/indigo/scenegraph/SceneUpdateFragment.scala
@@ -189,10 +189,20 @@ object SceneUpdateFragment:
           case x @ LayerEntry(k, ll, cfgA) if t == k =>
             val newLayer =
               (ll, l) match
-                case (a: Layer.Stack, b: Layer.Content)   => a.append(b)
-                case (a: Layer.Stack, b: Layer.Stack)     => a ++ b
-                case (a: Layer.Content, b: Layer.Content) => a |+| b
-                case (a: Layer.Content, b: Layer.Stack)   => a :: b
+                case (a: Layer.Stack, b: Layer.Content) =>
+                  a.append(b)
+
+                case (a: Layer.Stack, b: Layer.Stack) =>
+                  a ++ b
+
+                case (a: Layer.Content, b: Layer.Content) =>
+                  // For now, we add them both to a stack and move on, so as to preserve
+                  // possible differences in the layer properties, like blending.
+                  // Later in the pipeline they will be compacted, if they can be.
+                  Layer.Stack(a, b)
+
+                case (a: Layer.Content, b: Layer.Stack) =>
+                  a :: b
 
             LayerEntry(t, newLayer, cfgA |+| cfgB)
 

--- a/indigo-scenegraph/src/indigo/scenegraph/SceneUpdateFragment.scala
+++ b/indigo-scenegraph/src/indigo/scenegraph/SceneUpdateFragment.scala
@@ -1,6 +1,7 @@
 package indigo.scenegraph
 
 import indigo.core.datatypes.LayerKey
+import indigo.core.render.Magnification
 import indigo.scenegraph.materials.BlendMaterial
 import indigoengine.shared.collections.Batch
 
@@ -42,22 +43,13 @@ final case class SceneUpdateFragment(
 
   def addLayer(newLayer: LayerEntry): SceneUpdateFragment =
     SceneUpdateFragment.insertLayer(this, newLayer)
-  def addLayer(newLayer: Layer): SceneUpdateFragment =
-    SceneUpdateFragment.insertLayer(this, LayerEntry.NoKey(newLayer))
-  def addLayer(key: LayerKey, newLayer: Layer): SceneUpdateFragment =
-    SceneUpdateFragment.insertLayer(this, LayerEntry.Keyed(key, newLayer))
-  def addLayer(keyAndLayer: (LayerKey, Layer)): SceneUpdateFragment =
-    SceneUpdateFragment.insertLayer(this, LayerEntry.Keyed(keyAndLayer._1, keyAndLayer._2))
-  def addLayer(maybeKey: Option[LayerKey], newLayer: Layer): SceneUpdateFragment =
-    SceneUpdateFragment.insertLayer(this, LayerEntry(maybeKey, newLayer))
-  @targetName("addLayer_maybe_key_and_layer")
-  def addLayer(maybeKeyAndLayer: (Option[LayerKey], Layer)): SceneUpdateFragment =
-    SceneUpdateFragment.insertLayer(this, LayerEntry(maybeKeyAndLayer._1, maybeKeyAndLayer._2))
+  def addLayer(key: LayerKey)(newLayer: Layer): SceneUpdateFragment =
+    SceneUpdateFragment.insertLayer(this, LayerEntry(key, newLayer))
 
-  def addLayer(nodes: SceneNode*): SceneUpdateFragment =
-    addLayer(nodes.toBatch)
-  def addLayer(nodes: Batch[SceneNode]): SceneUpdateFragment =
-    SceneUpdateFragment.insertLayer(this, LayerEntry(Layer(nodes)))
+  def addLayer(key: LayerKey)(nodes: SceneNode*): SceneUpdateFragment =
+    addLayer(key)(nodes.toBatch)
+  def addLayer(key: LayerKey)(nodes: Batch[SceneNode]): SceneUpdateFragment =
+    SceneUpdateFragment.insertLayer(this, LayerEntry(key, Layer(nodes)))
 
   def addLayers(newLayers: Batch[LayerEntry]): SceneUpdateFragment =
     this.copy(layers = newLayers.foldLeft(layers)((acc, l) => SceneUpdateFragment.mergeLayers(acc, l)))
@@ -69,12 +61,6 @@ final case class SceneUpdateFragment(
   @targetName("addLayers_args_key_layer")
   def addLayers(newLayers: (LayerKey, Layer)*): SceneUpdateFragment =
     addLayers(newLayers.toBatch.map(p => LayerEntry(p._1, p._2)))
-  @targetName("addLayers_batch_layer")
-  def addLayers(newLayers: Batch[Layer]): SceneUpdateFragment =
-    addLayers(newLayers.map(LayerEntry.NoKey.apply))
-  @targetName("addLayers_args_layer")
-  def addLayers(newLayers: Layer*): SceneUpdateFragment =
-    addLayers(newLayers.toBatch.map(LayerEntry.NoKey.apply))
 
   def withLayers(layers: Batch[LayerEntry]): SceneUpdateFragment =
     this.copy(layers = layers)
@@ -82,20 +68,19 @@ final case class SceneUpdateFragment(
     withLayers(layers.toBatch)
   @targetName("withLayers_batch_key_layer")
   def withLayers(layers: Batch[(LayerKey, Layer)]): SceneUpdateFragment =
-    withLayers(layers.map(LayerEntry.apply))
+    withLayers(layers.map(p => LayerEntry(p._1, p._2)))
   @targetName("withLayers_args_key_layer")
   def withLayers(layers: (LayerKey, Layer)*): SceneUpdateFragment =
     withLayers(layers.toBatch)
-  @targetName("withLayers_batch_layer")
-  def withLayers(layers: Batch[Layer]): SceneUpdateFragment =
-    withLayers(layers.map(LayerEntry.apply))
-  @targetName("withLayers_args_layer")
-  def withLayers(layers: Layer*): SceneUpdateFragment =
-    withLayers(layers.toBatch.map(LayerEntry.apply))
 
   def modifyLayers(f: LayerEntry => LayerEntry): SceneUpdateFragment =
     this.copy(layers = layers.map(_.modify(f)))
 
+  /** Apply a magnification level to all LayerEntry instances contained in this SceneUpdateFragment */
+  def withMagnification(amount: Magnification): SceneUpdateFragment =
+    modifyLayers(_.withMagnification(amount))
+
+  /** Apply a magnification level to all LayerEntry instances contained in this SceneUpdateFragment */
   def noLights: SceneUpdateFragment =
     this.copy(lights = Batch.empty)
 
@@ -129,11 +114,6 @@ final case class SceneUpdateFragment(
   def modifyBlendMaterial(modifier: BlendMaterial => BlendMaterial): SceneUpdateFragment =
     this.copy(blendMaterial = blendMaterial.orElse(Option(BlendMaterial.Normal)).map(modifier))
 
-  def withMagnification(level: Int): SceneUpdateFragment =
-    this.copy(
-      layers = layers.map(_.withMagnificationForAll(level))
-    )
-
   def withCamera(newCamera: Camera): SceneUpdateFragment =
     this.copy(camera = Option(newCamera))
   def modifyCamera(modifier: Camera => Camera): SceneUpdateFragment =
@@ -144,65 +124,50 @@ final case class SceneUpdateFragment(
 object SceneUpdateFragment:
   import Batch.*
 
-  def apply(nodes: SceneNode*): SceneUpdateFragment =
-    SceneUpdateFragment(nodes.toBatch)
+  /* Constructors where you specify a layer key */
 
-  def apply(nodes: Batch[SceneNode]): SceneUpdateFragment =
-    SceneUpdateFragment(Batch(LayerEntry(Layer(nodes))), Batch.empty, None, None, Batch.empty, None)
-
-  def apply(maybeNode: Option[SceneNode]): SceneUpdateFragment =
+  def apply(key: LayerKey)(nodes: SceneNode*): SceneUpdateFragment =
+    SceneUpdateFragment(key)(nodes.toBatch)
+  def apply(key: LayerKey)(nodes: Batch[SceneNode]): SceneUpdateFragment =
+    SceneUpdateFragment(Batch(LayerEntry(key, Layer(nodes))), Batch.empty, None, None, Batch.empty, None)
+  def apply(key: LayerKey)(maybeNode: Option[SceneNode]): SceneUpdateFragment =
     SceneUpdateFragment(
-      Batch(LayerEntry(Layer(Batch.fromOption(maybeNode)))),
+      Batch(LayerEntry(key, Layer(Batch.fromOption(maybeNode)))),
       Batch.empty,
       None,
       None,
       Batch.empty,
       None
     )
-
-  def apply(key: LayerKey, layer: Layer): SceneUpdateFragment =
-    SceneUpdateFragment(Batch(LayerEntry.Keyed(key, layer)), Batch.empty, None, None, Batch.empty, None)
-  def apply(maybeKey: Option[LayerKey], layer: Layer): SceneUpdateFragment =
-    SceneUpdateFragment(Batch(LayerEntry(maybeKey, layer)), Batch.empty, None, None, Batch.empty, None)
+  def apply(key: LayerKey)(layer: Layer): SceneUpdateFragment =
+    SceneUpdateFragment(Batch(LayerEntry(key, layer)), Batch.empty, None, None, Batch.empty, None)
+  @targetName("suf-maybe-layer")
+  def apply(key: LayerKey)(maybeLayer: Option[Layer]): SceneUpdateFragment =
+    val layers = maybeLayer.map(l => Batch(LayerEntry(key, l))).getOrElse(Batch.empty)
+    SceneUpdateFragment(layers, Batch.empty, None, None, Batch.empty, None)
 
   @targetName("suf-maybe-layer-entry")
   def apply(maybeLayerEntry: Option[LayerEntry]): SceneUpdateFragment =
     val layers = maybeLayerEntry.map(l => Batch(l)).getOrElse(Batch.empty)
     SceneUpdateFragment(layers, Batch.empty, None, None, Batch.empty, None)
-  @targetName("suf-maybe-layer")
-  def apply(maybeLayer: Option[Layer]): SceneUpdateFragment =
-    val layers = maybeLayer.map(l => Batch(LayerEntry(l))).getOrElse(Batch.empty)
-    SceneUpdateFragment(layers, Batch.empty, None, None, Batch.empty, None)
   @targetName("suf-maybe-key-and-layer")
   def apply(maybeKeyAndLayer: Option[(LayerKey, Layer)]): SceneUpdateFragment =
-    val layers = maybeKeyAndLayer.map(l => Batch(LayerEntry(l))).getOrElse(Batch.empty)
+    val layers = maybeKeyAndLayer.map(l => Batch(LayerEntry(l._1, l._2))).getOrElse(Batch.empty)
     SceneUpdateFragment(layers, Batch.empty, None, None, Batch.empty, None)
 
   @targetName("suf-batch-layer-entry")
   def apply(layerEntries: Batch[LayerEntry]): SceneUpdateFragment =
     SceneUpdateFragment(layerEntries, Batch.empty, None, None, Batch.empty, None)
-  @targetName("suf-batch-layer")
-  def apply(layers: Batch[Layer]): SceneUpdateFragment =
-    SceneUpdateFragment(layers.map(LayerEntry.apply), Batch.empty, None, None, Batch.empty, None)
   @targetName("suf-batch-key-and-layer")
   def apply(keysAndLayers: Batch[(LayerKey, Layer)]): SceneUpdateFragment =
-    SceneUpdateFragment(keysAndLayers.map(LayerEntry.apply), Batch.empty, None, None, Batch.empty, None)
-  @targetName("suf-batch-maybe-key-and-layer")
-  def apply(maybeKeysAndLayers: Batch[(Option[LayerKey], Layer)]): SceneUpdateFragment =
-    SceneUpdateFragment(maybeKeysAndLayers.map(p => LayerEntry(p._1, p._2)), Batch.empty, None, None, Batch.empty, None)
+    SceneUpdateFragment(keysAndLayers.map(kl => LayerEntry(kl._1, kl._2)), Batch.empty, None, None, Batch.empty, None)
 
   @targetName("suf-apply-repeated-layer-entry")
   def apply(layerEntries: LayerEntry*): SceneUpdateFragment =
     SceneUpdateFragment(layerEntries.toBatch)
-  @targetName("suf-apply-repeated-layers")
-  def apply(layers: Layer*): SceneUpdateFragment =
-    SceneUpdateFragment(layers.toBatch)
   @targetName("suf-apply-repeated-keys-and-layers")
   def apply(keysAndLayers: (LayerKey, Layer)*): SceneUpdateFragment =
     SceneUpdateFragment(keysAndLayers.toBatch)
-  @targetName("suf-apply-repeated-maybe-keys-and-layers")
-  def apply(maybeKeysAndLayers: (Option[LayerKey], Layer)*): SceneUpdateFragment =
-    SceneUpdateFragment(maybeKeysAndLayers.toBatch)
 
   val empty: SceneUpdateFragment =
     SceneUpdateFragment(Batch.empty[LayerEntry])
@@ -217,17 +182,11 @@ object SceneUpdateFragment:
       b.camera.orElse(a.camera)
     )
 
-  private[scenegraph] def mergeLayers(layers: Batch[LayerEntry], layer: LayerEntry): Batch[LayerEntry] =
-    layer match
-      case l @ LayerEntry.NoKey(_) =>
-        layers :+ layer
-
-      case LayerEntry.Keyed(t, l) if layers.exists(_.hasKey(t)) =>
-        layers.map {
-          case x: LayerEntry.NoKey =>
-            x
-
-          case x @ LayerEntry.Keyed(k, ll) if t == k =>
+  private[scenegraph] def mergeLayers(existingLayers: Batch[LayerEntry], layerToMerge: LayerEntry): Batch[LayerEntry] =
+    layerToMerge match
+      case LayerEntry(t, l, cfgB) if existingLayers.exists(_.hasKey(t)) =>
+        existingLayers.map {
+          case x @ LayerEntry(k, ll, cfgA) if t == k =>
             val newLayer =
               (ll, l) match
                 case (a: Layer.Stack, b: Layer.Content)   => a.append(b)
@@ -235,14 +194,14 @@ object SceneUpdateFragment:
                 case (a: Layer.Content, b: Layer.Content) => a |+| b
                 case (a: Layer.Content, b: Layer.Stack)   => a :: b
 
-            LayerEntry.Keyed(t, newLayer)
+            LayerEntry(t, newLayer, cfgA |+| cfgB)
 
-          case x: LayerEntry.Keyed =>
+          case x: LayerEntry =>
             x
         }
 
-      case LayerEntry.Keyed(_, _) =>
-        layers :+ layer
+      case LayerEntry(_, _, _) =>
+        existingLayers :+ layerToMerge
 
   def insertLayer(suf: SceneUpdateFragment, layer: LayerEntry): SceneUpdateFragment =
     suf.copy(layers = mergeLayers(suf.layers, layer))

--- a/indigo-scenegraph/test/src/indigo/scenegraph/LayerTests.scala
+++ b/indigo-scenegraph/test/src/indigo/scenegraph/LayerTests.scala
@@ -1,5 +1,6 @@
 package indigo.scenegraph
 
+import indigo.core.datatypes.Point
 import indigo.scenegraph.materials.BlendMaterial
 import indigoengine.shared.collections.Batch
 import indigoengine.shared.datatypes.RGBA
@@ -82,10 +83,10 @@ class LayerTests extends munit.FunSuite {
   }
 
   test("modify - Content layer") {
-    val l = Layer.Content.empty.withMagnification(1)
+    val l = Layer.Content.empty.withCamera(Camera.Fixed(Point(1)))
 
-    val actual   = l.modify { case l: Layer.Content => l.withMagnification(2) }
-    val expected = Layer.Content.empty.withMagnification(2)
+    val actual   = l.modify { case l: Layer.Content => l.withCamera(Camera.Fixed(Point(2))) }
+    val expected = Layer.Content.empty.withCamera(Camera.Fixed(Point(2)))
 
     assertEquals(actual, expected)
   }
@@ -102,25 +103,25 @@ class LayerTests extends munit.FunSuite {
   test("modify - perform a deep modification") {
     val l = Layer.Stack(
       Layer.Stack(
-        Layer.Content.empty.withMagnification(1),
-        Layer.Content.empty.withMagnification(1),
-        Layer.Content.empty.withMagnification(1)
+        Layer.Content.empty.withCamera(Camera.Fixed(Point(1))),
+        Layer.Content.empty.withCamera(Camera.Fixed(Point(1))),
+        Layer.Content.empty.withCamera(Camera.Fixed(Point(1)))
       ),
-      Layer.Content.empty.withMagnification(1),
-      Layer.Content.empty.withMagnification(1),
-      Layer.Content.empty.withMagnification(1)
+      Layer.Content.empty.withCamera(Camera.Fixed(Point(1))),
+      Layer.Content.empty.withCamera(Camera.Fixed(Point(1))),
+      Layer.Content.empty.withCamera(Camera.Fixed(Point(1)))
     )
 
-    val actual = l.modify { case l: Layer.Content => l.withMagnification(2) }
+    val actual = l.modify { case l: Layer.Content => l.withCamera(Camera.Fixed(Point(2))) }
     val expected = Layer.Stack(
       Layer.Stack(
-        Layer.Content.empty.withMagnification(2),
-        Layer.Content.empty.withMagnification(2),
-        Layer.Content.empty.withMagnification(2)
+        Layer.Content.empty.withCamera(Camera.Fixed(Point(2))),
+        Layer.Content.empty.withCamera(Camera.Fixed(Point(2))),
+        Layer.Content.empty.withCamera(Camera.Fixed(Point(2)))
       ),
-      Layer.Content.empty.withMagnification(2),
-      Layer.Content.empty.withMagnification(2),
-      Layer.Content.empty.withMagnification(2)
+      Layer.Content.empty.withCamera(Camera.Fixed(Point(2))),
+      Layer.Content.empty.withCamera(Camera.Fixed(Point(2))),
+      Layer.Content.empty.withCamera(Camera.Fixed(Point(2)))
     )
 
     assertEquals(actual, expected)
@@ -129,16 +130,13 @@ class LayerTests extends munit.FunSuite {
   test("Layer.Stack cons") {
     val l = Layer.Stack(Layer.Content.empty, Layer.Content.empty, Layer.Content.empty)
 
-    val actual = Layer.Content.empty.withMagnification(2) :: l
+    val actual = Layer.Content.empty.withCamera(Camera.Fixed(Point(2))) :: l
 
     assertEquals(actual.layers.length, 4)
 
     actual.layers.head match
-      case Layer.Content(nodes, lights, magnification, visible, blending, cloneBlanks, camera) =>
-        assertEquals(
-          magnification,
-          Some(2)
-        )
+      case c: Layer.Content =>
+        assertEquals(c.camera, Some(Camera.Fixed(Point(2))))
 
       case _ =>
         fail("match failed")

--- a/indigo-scenegraph/test/src/indigo/scenegraph/SceneUpdateFragmentTests.scala
+++ b/indigo-scenegraph/test/src/indigo/scenegraph/SceneUpdateFragmentTests.scala
@@ -223,7 +223,10 @@ class SceneUpdateFragmentTests extends munit.FunSuite {
     val expected =
       SceneUpdateFragment.empty
         .addLayers(
-          LayerKey("a") -> Layer.Content.empty,
+          LayerKey("a") -> Layer.Stack(
+            Layer.Content.empty,
+            Layer.Content.empty
+          ),
           LayerKey("b") -> Layer.Stack(
             Layer.Content.empty,
             Layer.Stack(
@@ -245,6 +248,7 @@ class SceneUpdateFragmentTests extends munit.FunSuite {
 
     val expectedBatch =
       Batch(
+        Layer.Content.empty,
         Layer.Content.empty,
         Layer.Content.empty,
         Layer.Content.empty,

--- a/indigo-scenegraph/test/src/indigo/scenegraph/SceneUpdateFragmentTests.scala
+++ b/indigo-scenegraph/test/src/indigo/scenegraph/SceneUpdateFragmentTests.scala
@@ -1,6 +1,7 @@
 package indigo.scenegraph
 
 import indigo.core.datatypes.LayerKey
+import indigo.core.render.Magnification
 import indigo.scenegraph.materials.BlendMaterial
 import indigoengine.shared.collections.Batch
 import indigoengine.shared.datatypes.RGBA
@@ -35,7 +36,7 @@ class SceneUpdateFragmentTests extends munit.FunSuite {
   test("Able to add an optional layer from a constructor (None)") {
 
     val actual =
-      SceneUpdateFragment(Option.empty[Layer])
+      SceneUpdateFragment(Option.empty[LayerEntry])
 
     val expected =
       SceneUpdateFragment.empty
@@ -50,56 +51,56 @@ class SceneUpdateFragmentTests extends munit.FunSuite {
       SceneUpdateFragment.empty.addLayer(LayerEntry(LayerKey("key A"), Layer.empty))
 
     val actual =
-      scene.addLayer(LayerKey("key A") -> Layer.empty)
+      scene.addLayer(LayerEntry(LayerKey("key A"), Layer.empty))
 
     assert(actual.layers.length == 1)
-    assertEquals(actual.layers.flatMap(_.toBatch).head.magnification, None)
+    assertEquals(actual.layers.head.config.magnification.map(_.toInt), None)
 
   }
 
   test("Adding a layer with an existing key merges magnification down (some, some)") {
 
     val scene =
-      SceneUpdateFragment.empty.addLayer(LayerKey("key A") -> Layer.empty.withMagnification(2))
+      SceneUpdateFragment.empty.addLayer(LayerEntry(LayerKey("key A"), Layer.empty).withMagnification(Magnification.x2))
 
     val actual =
-      scene.addLayer(LayerEntry(LayerKey("key A"), Layer.empty.withMagnification(1)))
+      scene.addLayer(LayerEntry(LayerKey("key A"), Layer.empty).withMagnification(Magnification.x1))
 
     assert(actual.layers.length == 1)
-    assertEquals(actual.layers.flatMap(_.toBatch).head.magnification, Some(2))
+    assertEquals(actual.layers.head.config.magnification.map(_.toInt), Some(2))
 
   }
 
   test("Adding a layer with an existing key merges magnification down (none, some)") {
 
     val scene =
-      SceneUpdateFragment.empty.addLayer(LayerKey("key A") -> Layer.empty)
+      SceneUpdateFragment.empty.addLayer(LayerEntry(LayerKey("key A"), Layer.empty))
 
     val actual =
-      scene.addLayer(LayerKey("key A") -> Layer.empty.withMagnification(1))
+      scene.addLayer(LayerEntry(LayerKey("key A"), Layer.empty).withMagnification(Magnification.x1))
 
     assert(actual.layers.length == 1)
-    assertEquals(actual.layers.flatMap(_.toBatch).head.magnification, Some(1))
+    assertEquals(actual.layers.head.config.magnification.map(_.toInt), Some(1))
 
   }
 
   test("Adding a layer with an existing key merges magnification down (some, none)") {
 
     val scene =
-      SceneUpdateFragment.empty.addLayer(LayerKey("key A") -> Layer.empty.withMagnification(2))
+      SceneUpdateFragment.empty.addLayer(LayerEntry(LayerKey("key A"), Layer.empty).withMagnification(Magnification.x2))
 
     val actual =
-      scene.addLayer(LayerKey("key A") -> Layer.empty)
+      scene.addLayer(LayerEntry(LayerKey("key A"), Layer.empty))
 
     assert(actual.layers.length == 1)
-    assertEquals(actual.layers.flatMap(_.toBatch).head.magnification, Some(2))
+    assertEquals(actual.layers.head.config.magnification.map(_.toInt), Some(2))
 
   }
 
   test("Replace layers using withLayers") {
 
     val scene =
-      SceneUpdateFragment.empty.addLayer(LayerKey("key A") -> Layer.empty)
+      SceneUpdateFragment.empty.addLayers(LayerKey("key A") -> Layer.empty)
 
     val actual =
       scene.withLayers(LayerKey("key B") -> Layer.empty)
@@ -107,8 +108,7 @@ class SceneUpdateFragmentTests extends munit.FunSuite {
     assert(actual.layers.length == 1)
 
     actual.layers.head match
-      case LayerEntry.NoKey(_) => fail("Should have been a tagged layer entry")
-      case LayerEntry.Keyed(key, _) =>
+      case LayerEntry(key, _, _) =>
         assertEquals(key, LayerKey("key B"))
 
   }
@@ -116,16 +116,16 @@ class SceneUpdateFragmentTests extends munit.FunSuite {
   test("SUF append preseves layer keys") {
 
     val sceneA: SceneUpdateFragment =
-      SceneUpdateFragment.empty.addLayer(LayerKey("key A") -> Layer.empty.withMagnification(2))
+      SceneUpdateFragment.empty.addLayer(LayerEntry(LayerKey("key A"), Layer.empty).withMagnification(Magnification.x2))
 
     val sceneB: SceneUpdateFragment =
-      SceneUpdateFragment.empty.addLayer(LayerKey("key A") -> Layer.empty.withMagnification(3))
+      SceneUpdateFragment.empty.addLayer(LayerEntry(LayerKey("key A"), Layer.empty).withMagnification(Magnification.x3))
 
     val actual: SceneUpdateFragment =
       sceneA |+| sceneB
 
     assert(actual.layers.length == 1)
-    assertEquals(actual.layers.flatMap(_.toBatch).head.magnification, Some(2))
+    assertEquals(actual.layers.head.config.magnification.map(_.toInt), Some(2))
 
   }
 
@@ -156,37 +156,39 @@ class SceneUpdateFragmentTests extends munit.FunSuite {
   test("Modify layers") {
     val scene =
       SceneUpdateFragment.empty
-        .addLayer(LayerKey("key A") -> Layer.empty.withMagnification(1))
-        .addLayer(LayerKey("key B") -> Layer.empty.withMagnification(1))
+        .addLayer(LayerEntry(LayerKey("key A"), Layer.empty).withMagnification(Magnification.x1))
+        .addLayer(LayerEntry(LayerKey("key B"), Layer.empty).withMagnification(Magnification.x1))
 
     val actual =
-      scene.modifyLayers {
-        case LayerEntry.NoKey(_) =>
-          fail("Should have been a tagged layer entry")
-
-        case l @ LayerEntry.Keyed(key, layer) =>
-          l.withKey(LayerKey(key.toString + "?")).withMagnificationForAll(2)
+      scene.modifyLayers { case le @ LayerEntry(key, _, _) =>
+        le.withKey(LayerKey(key.show + "?")).withMagnification(Magnification.x2)
       }
 
-    assert(actual.layers.flatMap(_.toBatch).length == 2)
+    assert(actual.layers.length == 2)
 
     assertEquals(
-      actual.layers.map(_.giveKey.get).toList,
+      actual.layers.map(_.key).toList,
       List(LayerKey("key A?"), LayerKey("key B?"))
     )
-    assertEquals(actual.layers.flatMap(_.toBatch).map(_.magnification.get).toList, List(2, 2))
+    assertEquals(
+      actual.layers.map(_.config.magnification.map(_.toInt)).toList,
+      List(Some(2), Some(2))
+    )
   }
 
   test("Setting the magnification for all layers") {
     val scene =
       SceneUpdateFragment.empty
-        .addLayer(LayerKey("key A") -> Layer.empty.withMagnification(1))
-        .addLayer(LayerKey("key B") -> Layer.empty.withMagnification(1))
+        .addLayer(LayerEntry(LayerKey("key A"), Layer.empty).withMagnification(Magnification.x1))
+        .addLayer(LayerEntry(LayerKey("key B"), Layer.empty).withMagnification(Magnification.x1))
 
     val actual =
-      scene.withMagnification(2)
+      scene.withMagnification(Magnification.x2)
 
-    assertEquals(actual.layers.flatMap(_.toBatch).map(_.magnification.get).toList, List(2, 2))
+    assertEquals(
+      actual.layers.map(_.config.magnification.map(_.toInt)).toList,
+      List(Some(2), Some(2))
+    )
   }
 
   test("Merging SUF's with layer stacks") {
@@ -214,7 +216,6 @@ class SceneUpdateFragmentTests extends munit.FunSuite {
             Layer.Content.empty
           )
         )
-        .addLayer(Layer.empty)
 
     val actual =
       sceneA |+| sceneB
@@ -236,7 +237,6 @@ class SceneUpdateFragmentTests extends munit.FunSuite {
             Layer.Content.empty
           )
         )
-        .addLayer(Layer.empty)
 
     assertEquals(actual, expected)
 
@@ -245,7 +245,6 @@ class SceneUpdateFragmentTests extends munit.FunSuite {
 
     val expectedBatch =
       Batch(
-        Layer.Content.empty,
         Layer.Content.empty,
         Layer.Content.empty,
         Layer.Content.empty,

--- a/indigo/src-js/indigo/Game.scala
+++ b/indigo/src-js/indigo/Game.scala
@@ -412,7 +412,7 @@ object Game:
     ): Outcome[SceneUpdateFragment] =
       Outcome(
         SceneUpdateFragment(
-          Layer(
+          LayerKey("shaderplayground") -> Layer(
             BlankEntity(
               model.viewport,
               ShaderData(

--- a/indigo/src-native/indigo/Game.scala
+++ b/indigo/src-native/indigo/Game.scala
@@ -407,7 +407,7 @@ object Game:
     ): Outcome[SceneUpdateFragment] =
       Outcome(
         SceneUpdateFragment(
-          Layer(
+          LayerKey("shaderplayground") -> Layer(
             BlankEntity(
               model.viewport,
               ShaderData(

--- a/indigo/src/indigo/package.scala
+++ b/indigo/src/indigo/package.scala
@@ -20,6 +20,9 @@ object aliases:
   type ScreenCaptureConfig = indigo.core.render.ScreenCaptureConfig
   val ScreenCaptureConfig: indigo.core.render.ScreenCaptureConfig.type = indigo.core.render.ScreenCaptureConfig
 
+  type Magnification = indigo.core.render.Magnification
+  val Magnification: indigo.core.render.Magnification.type = indigo.core.render.Magnification
+
   val logger: indigo.core.utils.IndigoLogger.type = indigo.core.utils.IndigoLogger
 
   type Startup[SuccessType] = shared.Startup[SuccessType]

--- a/indigo/src/indigo/scenes/Scene.scala
+++ b/indigo/src/indigo/scenes/Scene.scala
@@ -3,10 +3,8 @@ package indigo.scenes
 import indigo.core.Outcome
 import indigo.core.events.EventFilters
 import indigo.core.events.GlobalEvent
-import indigo.scenegraph.Layer
 import indigo.scenegraph.SceneUpdateFragment
 import indigo.shared.subsystems.SubSystem
-import indigoengine.shared.collections.Batch
 import indigoengine.shared.optics.Lens
 
 /** Describes the functions that a valid scene must implement.
@@ -50,7 +48,7 @@ object Scene {
       type SceneModel = Unit
 
       val sceneFragment =
-        Outcome(SceneUpdateFragment(Batch.empty[Layer]))
+        Outcome(SceneUpdateFragment.empty)
 
       val modelOutcome = Outcome(())
 

--- a/roguelike-starterkit-demo/src/demo/Constants.scala
+++ b/roguelike-starterkit-demo/src/demo/Constants.scala
@@ -1,5 +1,13 @@
 package demo
 
+import indigo.*
+
 object Constants:
 
-  val magnification: Int = 1
+  val magnification: Magnification = Magnification.x2
+
+  object LayerKeys:
+    val background: LayerKey = LayerKey("background")
+    val game: LayerKey       = LayerKey("game")
+    val ui: LayerKey         = LayerKey("ui")
+    val fps: LayerKey        = LayerKey("fps")

--- a/roguelike-starterkit-demo/src/demo/RogueLikeGame.scala
+++ b/roguelike-starterkit-demo/src/demo/RogueLikeGame.scala
@@ -46,8 +46,9 @@ final class RogueLikeGame() extends Game[Unit, Unit, GameModel]:
         .withSubSystems(
           FPSCounter(
             RoguelikeTiles.Size10x10.Fonts.fontKey,
-            Assets.assets.AnikkiSquare10x10
-          ).moveTo(Point(10, 350))
+            Assets.assets.AnikkiSquare10x10,
+            Constants.LayerKeys.fps
+          ) // .moveTo(Point(10, 10))
         )
     )
 
@@ -77,7 +78,16 @@ final class RogueLikeGame() extends Game[Unit, Unit, GameModel]:
       context: Context,
       model: GameModel
   ): Outcome[SceneUpdateFragment] =
-    Outcome(SceneUpdateFragment.empty)
+    Outcome(
+      SceneUpdateFragment(
+        Constants.LayerKeys.background -> Layer.empty,
+        Constants.LayerKeys.game       -> Layer.empty,
+        Constants.LayerKeys.ui         -> Layer.empty
+      )
+        .addLayers(
+          LayerEntry(Constants.LayerKeys.fps, Layer.empty, Magnification.x2)
+        )
+    )
 
 enum GameEvent extends GlobalEvent:
   case NoOp

--- a/roguelike-starterkit-demo/src/demo/scenes/ColourWindowScene.scala
+++ b/roguelike-starterkit-demo/src/demo/scenes/ColourWindowScene.scala
@@ -25,11 +25,11 @@ object ColourWindowScene extends Scene[GameModel]:
     Set(
       WindowManager[GameModel, Unit](
         SubSystemId("window manager"),
+        Constants.LayerKeys.ui,
         Constants.magnification,
         Size(GameModel.defaultCharSheet.charSize),
         _ => ()
       )
-        .withLayerKey(LayerKey("UI Layer"))
         .register(
           ColourWindow.window(
             GameModel.defaultCharSheet
@@ -91,7 +91,6 @@ object ColourWindowScene extends Scene[GameModel]:
                   model.pointerOverWindows.mkString("[", ",", "]")
               )
               .moveTo(0, 260)
-          ),
-        LayerKey("UI Layer") -> Layer.Stack.empty
-      )
+          )
+      ).withMagnification(Magnification.x2)
     )

--- a/roguelike-starterkit-demo/src/demo/scenes/LightingScene.scala
+++ b/roguelike-starterkit-demo/src/demo/scenes/LightingScene.scala
@@ -1,6 +1,7 @@
 package demo.scenes
 
 import demo.Assets
+import demo.Constants
 import demo.models.GameModel
 import indigo.*
 import roguelikestarterkit.*
@@ -65,7 +66,8 @@ object LightingScene extends Scene[GameModel]:
     val pt = Signal.Orbit(Point(50), 20).affectTime(0.5).at(context.sceneRunning).toPoint
 
     Outcome(
-      tiles.toSceneUpdateFragment
+      tiles
+        .toSceneUpdateFragment(Constants.LayerKeys.game)
         .withLights(
           AmbientLight(RGBA.Red),
           PointLight(pt, RGBA.White)

--- a/roguelike-starterkit-demo/src/demo/scenes/MultipleWindowsScene.scala
+++ b/roguelike-starterkit-demo/src/demo/scenes/MultipleWindowsScene.scala
@@ -25,6 +25,7 @@ object MultipleWindowsScene extends Scene[GameModel]:
     Set(
       WindowManager[GameModel, Int](
         SubSystemId("window manager 2"),
+        Constants.LayerKeys.ui,
         Constants.magnification,
         Size(GameModel.defaultCharSheet.charSize),
         _.pointerOverWindows.length

--- a/roguelike-starterkit-demo/src/demo/scenes/NoTerminalUI.scala
+++ b/roguelike-starterkit-demo/src/demo/scenes/NoTerminalUI.scala
@@ -1,6 +1,7 @@
 package demo.scenes
 
 import demo.Assets
+import demo.Constants
 import demo.GameEvent
 import demo.models.ChangeValue
 import demo.models.GameModel
@@ -37,7 +38,7 @@ object NoTerminalUI extends Scene[GameModel]:
 
     case e =>
       val ctx =
-        UIContext(context.toContext.forSubSystems.copy(reference = model.num), Size(1), 1)
+        UIContext(context.toContext.forSubSystems.copy(reference = model.num), Size(1), Magnification.x1)
       summon[Component[ComponentGroup[Int], Int]].updateModel(ctx, model.components)(e).map { cl =>
         model.copy(components = cl)
       }
@@ -47,8 +48,8 @@ object NoTerminalUI extends Scene[GameModel]:
       model: GameModel
   ): Outcome[SceneUpdateFragment] =
     model.components
-      .present(UIContext(context.toContext.forSubSystems.copy(reference = 0), Size(1), 1))
-      .map(l => SceneUpdateFragment(l))
+      .present(UIContext(context.toContext.forSubSystems.copy(reference = 0), Size(1), Magnification.x1))
+      .map(l => SceneUpdateFragment(Constants.LayerKeys.game -> l))
 
 object NoTerminalUIComponents:
 

--- a/roguelike-starterkit-demo/src/demo/scenes/RogueTerminalEmulatorScene.scala
+++ b/roguelike-starterkit-demo/src/demo/scenes/RogueTerminalEmulatorScene.scala
@@ -1,6 +1,7 @@
 package demo.scenes
 
 import demo.Assets
+import demo.Constants
 import demo.models.GameModel
 import indigo.*
 import roguelikestarterkit.*
@@ -49,4 +50,4 @@ object RogueTerminalEmulatorScene extends Scene[GameModel]:
         Graphic(10, 10, TerminalMaterial(Assets.assets.AnikkiSquare10x10, fg, bg))
       }
 
-    Outcome(tiles.toSceneUpdateFragment)
+    Outcome(tiles.toSceneUpdateFragment(Constants.LayerKeys.game).withMagnification(Magnification.x3))

--- a/roguelike-starterkit-demo/src/demo/scenes/TerminalEmulatorScene.scala
+++ b/roguelike-starterkit-demo/src/demo/scenes/TerminalEmulatorScene.scala
@@ -1,6 +1,7 @@
 package demo.scenes
 
 import demo.Assets
+import demo.Constants
 import demo.models.GameModel
 import indigo.*
 import roguelikestarterkit.*
@@ -54,6 +55,7 @@ object TerminalEmulatorScene extends Scene[GameModel]:
       }
 
     Outcome(
-      SceneUpdateFragment(tiles.clones)
+      SceneUpdateFragment(Constants.LayerKeys.game)(tiles.clones)
         .addCloneBlanks(tiles.blanks)
+        .withMagnification(Magnification.x2)
     )

--- a/roguelike-starterkit-demo/src/demo/scenes/TerminalTextScene.scala
+++ b/roguelike-starterkit-demo/src/demo/scenes/TerminalTextScene.scala
@@ -1,6 +1,7 @@
 package demo.scenes
 
 import demo.Assets
+import demo.Constants
 import demo.models.GameModel
 import indigo.*
 import roguelikestarterkit.*
@@ -41,7 +42,7 @@ object TerminalTextScene extends Scene[GameModel]:
       model: GameModel
   ): Outcome[SceneUpdateFragment] =
     Outcome(
-      SceneUpdateFragment(
+      SceneUpdateFragment(Constants.LayerKeys.game)(
         Text(
           message,
           RoguelikeTiles.Size10x10.Fonts.fontKey,
@@ -63,7 +64,7 @@ object TerminalTextScene extends Scene[GameModel]:
             RGBA.Magenta.withAlpha(0.75)
           )
         ).moveBy(0, 80)
-      )
+      ).withMagnification(Magnification.x2)
     )
 
   def customShader(shaderId: ShaderId): UltravioletShader =

--- a/roguelike-starterkit-demo/src/demo/scenes/TerminalUI.scala
+++ b/roguelike-starterkit-demo/src/demo/scenes/TerminalUI.scala
@@ -1,6 +1,7 @@
 package demo.scenes
 
 import demo.Assets
+import demo.Constants
 import demo.GameEvent
 import demo.models.GameModel
 import indigo.*
@@ -34,7 +35,7 @@ object TerminalUI extends Scene[GameModel]:
       Outcome(model)
 
     case e =>
-      val ctx = UIContext(context.toContext, 1)
+      val ctx = UIContext(context.toContext, Magnification.x3)
         .withSnapGrid(TerminalUIComponents.charSheet.size)
         .moveParentBy(Coords(5, 5))
 
@@ -46,13 +47,16 @@ object TerminalUI extends Scene[GameModel]:
       context: SceneContext,
       model: GameModel
   ): Outcome[SceneUpdateFragment] =
-    val ctx = UIContext(context.toContext, 1)
+    val ctx = UIContext(context.toContext, Magnification.x3)
       .withSnapGrid(TerminalUIComponents.charSheet.size)
       .moveParentBy(Coords(5, 5))
 
     model.button
       .present(ctx)
-      .map(l => SceneUpdateFragment(l))
+      .map { l =>
+        SceneUpdateFragment(Constants.LayerKeys.ui)(l)
+          .withMagnification(Magnification.x3)
+      }
 
 object TerminalUIComponents:
 

--- a/roguelike-starterkit-demo/src/demo/scenes/WindowDemoScene.scala
+++ b/roguelike-starterkit-demo/src/demo/scenes/WindowDemoScene.scala
@@ -23,6 +23,7 @@ object WindowDemoScene extends Scene[GameModel]:
     Set(
       WindowManager[GameModel](
         SubSystemId("demo window manager"),
+        Constants.LayerKeys.ui,
         Constants.magnification
       )
         .withLayerKey(LayerKey("UI Layer"))

--- a/roguelike-starterkit-demo/src/demo/windows/ColourWindow.scala
+++ b/roguelike-starterkit-demo/src/demo/windows/ColourWindow.scala
@@ -84,7 +84,7 @@ object ColourWindow:
       .withBackground { bounds =>
         Layer(
           Shape.Box(
-            bounds.toScreenSpace(charSheet.size),
+            bounds.toLocalSpace(charSheet.size),
             Fill.Color(RGBA.Cyan.withAlpha(0.5))
           )
         )
@@ -102,8 +102,8 @@ object ColourWindow:
             case None =>
               Shape.Box(
                 Rectangle(
-                  ctx.parent.coords.toScreenSpace(charSheet.size),
-                  btn.bounds(ctx).dimensions.toScreenSpace(charSheet.size)
+                  ctx.parent.coords.toLocalSpace(charSheet.size),
+                  btn.bounds(ctx).dimensions.toLocalSpace(charSheet.size)
                 ),
                 Fill.Color(colour)
               )
@@ -111,8 +111,8 @@ object ColourWindow:
             case Some(strokeColor) =>
               Shape.Box(
                 Rectangle(
-                  ctx.parent.coords.toScreenSpace(charSheet.size),
-                  btn.bounds(ctx).dimensions.toScreenSpace(charSheet.size)
+                  ctx.parent.coords.toLocalSpace(charSheet.size),
+                  btn.bounds(ctx).dimensions.toLocalSpace(charSheet.size)
                 ),
                 Fill.Color(colour),
                 Stroke(2, strokeColor)

--- a/roguelike-starterkit-demo/src/demo/windows/ComponentsWindow.scala
+++ b/roguelike-starterkit-demo/src/demo/windows/ComponentsWindow.scala
@@ -81,8 +81,8 @@ object ComponentsWindow:
               Shape.Box(
                 btn
                   .bounds(ctx)
-                  .toScreenSpace(charSheet.size)
-                  .moveTo(ctx.parent.coords.toScreenSpace(charSheet.size)),
+                  .toLocalSpace(charSheet.size)
+                  .moveTo(ctx.parent.coords.toLocalSpace(charSheet.size)),
                 Fill.LinearGradient(Point.zero, RGBA.Cyan, Point(50, 0), RGBA.Magenta)
               )
             )
@@ -98,7 +98,7 @@ object ComponentsWindow:
               .putLine(Point.zero, label.text(ctx), RGBA.Red, RGBA.Zero)
               .toCloneTiles(
                 CloneId("label"),
-                ctx.parent.coords.toScreenSpace(charSheet.size),
+                ctx.parent.coords.toLocalSpace(charSheet.size),
                 charSheet.charCrops
               ) { case (fg, bg) =>
                 graphic.withMaterial(TerminalMaterial(charSheet.assetName, fg, bg))

--- a/roguelike-starterkit-demo/src/demo/windows/ComponentsWindow2.scala
+++ b/roguelike-starterkit-demo/src/demo/windows/ComponentsWindow2.scala
@@ -74,8 +74,8 @@ object ComponentsWindow2:
             Layer(
               Shape.Box(
                 Rectangle(
-                  bounds.coords.toScreenSpace(charSheet.size),
-                  bounds.dimensions.toScreenSpace(charSheet.size)
+                  bounds.coords.toLocalSpace(charSheet.size),
+                  bounds.dimensions.toLocalSpace(charSheet.size)
                 ),
                 Fill.Color(RGBA.Magenta.withAlpha(0.5))
               )

--- a/roguelike-starterkit-demo/src/demo/windows/DemoWindow.scala
+++ b/roguelike-starterkit-demo/src/demo/windows/DemoWindow.scala
@@ -25,7 +25,7 @@ object DemoWindow:
                 .Bitmap(Assets.assets.window)
                 .nineSlice(Rectangle(3, 15, 121, 41))
             ),
-            Shape.Box(ctx.bounds.toScreenSpace(Size(1)), Fill.None, Stroke(1, RGBA.Green))
+            Shape.Box(ctx.bounds.toLocalSpace(Size(1)), Fill.None, Stroke(1, RGBA.Green))
           )
         )
       }

--- a/roguelike-starterkit/src/roguelikestarterkit/terminal/TerminalClones.scala
+++ b/roguelike-starterkit/src/roguelikestarterkit/terminal/TerminalClones.scala
@@ -11,9 +11,9 @@ final case class TerminalClones(blanks: Batch[CloneBlank], clones: Batch[CloneTi
   def combine(other: TerminalClones): TerminalClones =
     TerminalClones(blanks ++ other.blanks, clones ++ other.clones)
 
-  def toSceneUpdateFragment: SceneUpdateFragment =
+  def toSceneUpdateFragment(layerKey: LayerKey): SceneUpdateFragment =
     SceneUpdateFragment(
-      Batch(LayerEntry(Layer.Content(clones))),
+      Batch(LayerEntry(layerKey, Layer.Content(clones))),
       Batch.empty,
       None,
       None,
@@ -24,11 +24,9 @@ final case class TerminalClones(blanks: Batch[CloneBlank], clones: Batch[CloneTi
   def toLayer: Layer.Content =
     Layer.Content(
       clones,
+      blanks,
       Batch.empty,
       None,
-      None,
-      None,
-      blanks,
       None
     )
 

--- a/roguelike-starterkit/src/roguelikestarterkit/ui/components/TerminalButton.scala
+++ b/roguelike-starterkit/src/roguelikestarterkit/ui/components/TerminalButton.scala
@@ -43,8 +43,8 @@ object TerminalButton:
             .toCloneTiles(
               CloneId(s"button_${charSheet.assetName.toString}"),
               button.bounds.coords
-                .toScreenSpace(charSheet.size)
-                .moveBy(context.parent.coords.toScreenSpace(charSheet.size)),
+                .toLocalSpace(charSheet.size)
+                .moveBy(context.parent.coords.toLocalSpace(charSheet.size)),
               charSheet.charCrops
             ) { case (fg, bg) =>
               graphic.withMaterial(TerminalMaterial(charSheet.assetName, fg, bg))
@@ -86,8 +86,8 @@ object TerminalButton:
             .toCloneTiles(
               CloneId(s"button_${charSheet.assetName.toString}"),
               bounds.coords
-                .toScreenSpace(charSheet.size)
-                .moveBy(context.parent.coords.toScreenSpace(charSheet.size)),
+                .toLocalSpace(charSheet.size)
+                .moveBy(context.parent.coords.toLocalSpace(charSheet.size)),
               charSheet.charCrops
             ) { case (fg, bg) =>
               graphic.withMaterial(TerminalMaterial(charSheet.assetName, fg, bg))

--- a/roguelike-starterkit/src/roguelikestarterkit/ui/components/TerminalInput.scala
+++ b/roguelike-starterkit/src/roguelikestarterkit/ui/components/TerminalInput.scala
@@ -43,7 +43,7 @@ object TerminalInput:
     Batch(
       Shape.Box(
         Rectangle(
-          (offset + Coords(cursorPosition, 0) + 1).toScreenSpace(charSheet.size),
+          (offset + Coords(cursorPosition, 0) + 1).toLocalSpace(charSheet.size),
           Size(
             Math.max(1, charSheet.size.width / 5).toInt,
             charSheet.size.height
@@ -94,8 +94,8 @@ object TerminalInput:
             .toCloneTiles(
               CloneId(s"input_${charSheet.assetName.toString}"),
               bounds.coords
-                .toScreenSpace(charSheet.size)
-                .moveBy(context.parent.coords.toScreenSpace(charSheet.size)),
+                .toLocalSpace(charSheet.size)
+                .moveBy(context.parent.coords.toLocalSpace(charSheet.size)),
               charSheet.charCrops
             ) { case (fg, bg) =>
               graphic.withMaterial(TerminalMaterial(charSheet.assetName, fg, bg))

--- a/roguelike-starterkit/src/roguelikestarterkit/ui/components/TerminalLabel.scala
+++ b/roguelike-starterkit/src/roguelikestarterkit/ui/components/TerminalLabel.scala
@@ -31,7 +31,7 @@ object TerminalLabel:
           .putLine(Point.zero, label.text(context), fgColor, bgColor)
           .toCloneTiles(
             CloneId(s"label_${charSheet.assetName.toString}"),
-            context.parent.coords.toScreenSpace(charSheet.size),
+            context.parent.coords.toLocalSpace(charSheet.size),
             charSheet.charCrops
           ) { case (fg, bg) =>
             graphic.withMaterial(TerminalMaterial(charSheet.assetName, fg, bg))

--- a/roguelike-starterkit/src/roguelikestarterkit/ui/components/TerminalScrollPane.scala
+++ b/roguelike-starterkit/src/roguelikestarterkit/ui/components/TerminalScrollPane.scala
@@ -151,7 +151,7 @@ object TerminalScrollPane:
       bounds =>
         Layer(
           Shape.Box(
-            bounds.toScreenSpace(charSheet.size),
+            bounds.toLocalSpace(charSheet.size),
             defaultBgColor
           )
         )

--- a/roguelike-starterkit/src/roguelikestarterkit/ui/components/TerminalSwitch.scala
+++ b/roguelike-starterkit/src/roguelikestarterkit/ui/components/TerminalSwitch.scala
@@ -25,8 +25,8 @@ object TerminalSwitch:
           .toCloneTiles(
             CloneId(s"switch_${charSheet.assetName.toString}"),
             bounds.coords
-              .toScreenSpace(charSheet.size)
-              .moveBy(context.parent.coords.toScreenSpace(charSheet.size)),
+              .toLocalSpace(charSheet.size)
+              .moveBy(context.parent.coords.toLocalSpace(charSheet.size)),
             charSheet.charCrops
           ) { case (fg, bg) =>
             graphic.withMaterial(TerminalMaterial(charSheet.assetName, fg, bg))

--- a/roguelike-starterkit/src/roguelikestarterkit/ui/components/TerminalTextArea.scala
+++ b/roguelike-starterkit/src/roguelikestarterkit/ui/components/TerminalTextArea.scala
@@ -37,7 +37,7 @@ object TerminalTextArea:
         )
         .toCloneTiles(
           CloneId(s"label_${charSheet.assetName.toString}"),
-          context.parent.coords.toScreenSpace(charSheet.size),
+          context.parent.coords.toLocalSpace(charSheet.size),
           charSheet.charCrops
         ) { case (fg, bg) =>
           graphic.withMaterial(TerminalMaterial(charSheet.assetName, fg, bg))

--- a/roguelike-starterkit/src/roguelikestarterkit/ui/window/TerminalWindow.scala
+++ b/roguelike-starterkit/src/roguelikestarterkit/ui/window/TerminalWindow.scala
@@ -81,7 +81,7 @@ object TerminalWindow:
         .put(tiles)
         .toCloneTiles(
           CloneId("terminal_window_tile_clone_id"),
-          context.bounds.coords.toScreenSpace(charSheet.size),
+          context.bounds.coords.toLocalSpace(charSheet.size),
           charSheet.charCrops
         ) { case (fg, bg) =>
           graphic.withMaterial(TerminalMaterial(charSheet.assetName, fg, bg))

--- a/ultraviolet-sandbox/src/com/example/sandbox/SandboxGame.scala
+++ b/ultraviolet-sandbox/src/com/example/sandbox/SandboxGame.scala
@@ -110,7 +110,10 @@ final class SandboxGame extends Game[SandboxBootData, SandboxStartupData, Sandbo
       model: SandboxGameModel
   ): Outcome[SceneUpdateFragment] =
     Outcome(
-      SceneUpdateFragment.empty
+      SceneUpdateFragment(
+        SandboxView.bgLayerKey   -> Layer.empty,
+        SandboxView.gameLayerKey -> Layer.empty
+      )
     )
 
 final case class Dude(

--- a/ultraviolet-sandbox/src/com/example/sandbox/SandboxView.scala
+++ b/ultraviolet-sandbox/src/com/example/sandbox/SandboxView.scala
@@ -4,6 +4,9 @@ import indigo.*
 
 object SandboxView:
 
+  val bgLayerKey: LayerKey   = LayerKey("bg")
+  val gameLayerKey: LayerKey = LayerKey("game")
+
   val dudeCloneId: CloneId = CloneId("Dude")
 
   def updateView(
@@ -15,13 +18,13 @@ object SandboxView:
       println("Mouse clicked at: " + pt.toString())
 
     SceneUpdateFragment.empty
-      .addLayer(
+      .addLayer(gameLayerKey)(
         Layer(
           gameLayer(model, model.viewModel) ++ uiLayer(bl)
         )
         // .withBlend(Blend.Alpha)
       )
-      .addLayer(
+      .addLayer(gameLayerKey)(
         if (model.viewModel.useLightingLayer)
           Layer(lightingLayer(mouse))
             .withBlending(Blending.Lighting(RGBA.White.withAlpha(0.25)))

--- a/ultraviolet-sandbox/src/com/example/sandbox/scenes/NoiseScene.scala
+++ b/ultraviolet-sandbox/src/com/example/sandbox/scenes/NoiseScene.scala
@@ -1,6 +1,7 @@
 package com.example.sandbox.scenes
 
 import com.example.sandbox.SandboxGameModel
+import com.example.sandbox.SandboxView
 import com.example.sandbox.shaders.*
 import indigo.*
 import indigo.scenes.*
@@ -33,7 +34,7 @@ object NoiseScene extends Scene[SandboxGameModel] {
   ): Outcome[SceneUpdateFragment] =
     Outcome(
       SceneUpdateFragment(
-        Layer(
+        SandboxView.gameLayerKey -> Layer(
           BlankEntity(100, 100, ShaderData(CellularNoiseShader.shader.id))
             .moveTo(0, 0),
           BlankEntity(100, 100, ShaderData(PerlinNoiseShader.shader.id))
@@ -44,7 +45,7 @@ object NoiseScene extends Scene[SandboxGameModel] {
             .moveTo(0, 100),
           BlankEntity(100, 100, ShaderData(WhiteNoiseShader.shader.id))
             .moveTo(100, 100)
-        ).withMagnification(1)
+        )
       )
     )
 

--- a/ultraviolet-sandbox/src/com/example/sandbox/scenes/OriginalScene.scala
+++ b/ultraviolet-sandbox/src/com/example/sandbox/scenes/OriginalScene.scala
@@ -44,12 +44,11 @@ object OriginalScene extends Scene[SandboxGameModel] {
 
     Outcome(
       SceneUpdateFragment.empty
-        .addLayer(
-          LayerKey("bg") -> Layer.empty
-            .withMagnification(1)
+        .addLayers(
+          SandboxView.bgLayerKey -> Layer.empty
         ) |+| scene
-        .addLayer(
-          LayerKey("bg") -> Layer(
+        .addLayers(
+          SandboxView.bgLayerKey -> Layer(
             CustomShape(
               0,
               0,
@@ -59,8 +58,8 @@ object OriginalScene extends Scene[SandboxGameModel] {
             )
           )
         )
-        .addLayer(
-          Layer(
+        .addLayers(
+          SandboxView.gameLayerKey -> Layer(
             Graphic(120, 10, 32, 32, SandboxAssets.dotsMaterial),
             CustomShape(
               140,

--- a/ultraviolet-sandbox/src/com/example/sandbox/scenes/ShadersScene.scala
+++ b/ultraviolet-sandbox/src/com/example/sandbox/scenes/ShadersScene.scala
@@ -1,6 +1,7 @@
 package com.example.sandbox.scenes
 
 import com.example.sandbox.SandboxGameModel
+import com.example.sandbox.SandboxView
 import com.example.sandbox.shaders.*
 import indigo.*
 import indigo.scenes.*
@@ -33,7 +34,7 @@ object ShadersScene extends Scene[SandboxGameModel] {
   ): Outcome[SceneUpdateFragment] =
     Outcome(
       SceneUpdateFragment(
-        Layer(
+        SandboxView.gameLayerKey -> Layer(
           BlankEntity(100, 100, ShaderData(BoxShader.shader.id))
             .moveTo(0, 0),
           BlankEntity(100, 100, ShaderData(CircleShader.shader.id))
@@ -46,7 +47,7 @@ object ShadersScene extends Scene[SandboxGameModel] {
             .moveTo(100, 100),
           BlankEntity(100, 100, ShaderData(TriangleShader.shader.id))
             .moveTo(200, 100)
-        ).withMagnification(1)
+        )
       )
     )
 


### PR DESCRIPTION
Relates to specifically the first issue in this list, but also the others:

- https://github.com/PurpleKingdomGames/indigoengine/issues/217
- https://github.com/PurpleKingdomGames/indigoengine/issues/123
- https://github.com/PurpleKingdomGames/indigoengine/issues/124
- https://github.com/PurpleKingdomGames/indigoengine/issues/125

The 0.30.0-Mx-PREVIEW line of releases contained one major regression, which was that since Tyrian now owns pointer / mouse input but had no understanding of Indigo's global magnification, the two did not correlate in any way. Global magnification was then removed in an earlier release.

The knock on effect was that all of the UI stuff stopped working consistently at any magnification other than 1:1, as there was too many assumptions about where magnification was being handled.

On top of all that, there was another lurking bug where if you magnified nested layers (i.e. local rather than global magnification) the magnification values would compound giving unexpected layer scaling behaviour.

This PR fixes all of that, at the cost of a breaking API change, but as usual, I consider that acceptable. Specifically:

1. `Magnification` now has it's own real type, it isn't just an `Int` any more.
2. Layers can no longer by magnified, magnification AND visibility can only occur at the `LayerEntry` level, this means that `LayerEntry`s are effectively the configuration for a stack of `Layer`s.
3. Numerous constructors and modifiers have been reworked at the `SceneUpdateFragment`, `Layer.Content`, `Layer.Stack`, and `LayerEntry` level.
4. `LayerEntry` instances now have a `LayerConfig` member.
5. `LayerKey` are mandatory for `LayerEntry` instances.
6. All notions of magnifying all layers under this one have also gone, naturally.

LayerEntry instance carry on with our left-bias semi-group-esque merging habits. This means that at the top level of you game you can declare:

`LayerKey("ui") -> Layer.empty`

And later on (such as in the `WindowManager`) you can redeclare the same entry, but also give it a magnification. The new entry will be merged with the top level entry, but will keep the new magnification. IF however, the top level version had purposefully declared a specific magnification, that is the one that will be used.