### PR TITLE
Removes deprecated properties from pointer events

### DIFF
--- a/indigo-core/src/indigo/core/events/InputEvent.scala
+++ b/indigo-core/src/indigo/core/events/InputEvent.scala
@@ -3,11 +3,6 @@ package indigo.core.events
 import indigo.core.constants.Key
 import indigo.core.datatypes.Point
 import indigo.core.events.MouseEvent.Move
-import indigo.core.events.MouseEvent.Wheel
-import indigoengine.shared.collections.Batch
-import indigoengine.shared.datatypes.Radians
-
-import scala.annotation.nowarn
 
 /** Tags events for input devices like mice and keyboards. `InputEvent`s work in partnership with `InputState`. Events
   * represent a one time thing that happened since the last frame, while the state represents the _ongoing_ state of an
@@ -130,7 +125,6 @@ sealed trait MouseEvent extends PositionalInputEvent:
     */
   def movementPosition: Point
 
-@nowarn("msg=deprecated")
 object MouseEvent:
 
   /** The mouse button was clicked
@@ -147,102 +141,26 @@ object MouseEvent:
   final case class Click(
       pointerId: PointerId,
       position: Point,
-      @deprecated("Use `InputState.mouse.buttons` instead", "0.22.0")
-      buttons: Batch[MouseButton],
-      @deprecated("Use `InputState.keyboard.isAltKeyDown` instead", "0.22.0")
-      isAltKeyDown: Boolean,
-      @deprecated("Use `InputState.keyboard.isCtrlKeyDown` instead", "0.22.0")
-      isCtrlKeyDown: Boolean,
-      @deprecated("Use `InputState.keyboard.isMetaKeyDown` instead", "0.22.0")
-      isMetaKeyDown: Boolean,
-      @deprecated("Use `InputState.keyboard.isShiftKeyDown` instead", "0.22.0")
-      isShiftKeyDown: Boolean,
       movementPosition: Point,
       button: MouseButton
   ) extends MouseEvent
   object Click:
-    @nowarn("msg=deprecated")
     def apply(x: Int, y: Int): Click =
       Click(
         PointerId.unknown,
         position = Point(x, y),
-        buttons = Batch.empty,
-        isAltKeyDown = false,
-        isCtrlKeyDown = false,
-        isMetaKeyDown = false,
-        isShiftKeyDown = false,
         movementPosition = Point.zero,
         button = MouseButton.LeftMouseButton
       )
-    @nowarn("msg=deprecated")
+
     def apply(position: Point): Click =
       Click(
         PointerId.unknown,
         position = position,
-        buttons = Batch.empty,
-        isAltKeyDown = false,
-        isCtrlKeyDown = false,
-        isMetaKeyDown = false,
-        isShiftKeyDown = false,
         movementPosition = Point.zero,
         button = MouseButton.LeftMouseButton
       )
     def unapply(e: Click): Option[Point] =
-      Option(e.position)
-
-  @deprecated("Use `MouseEvents.Up` instead", "0.22.0")
-  final case class MouseUp(
-      pointerId: PointerId,
-      position: Point,
-      buttons: Batch[MouseButton],
-      isAltKeyDown: Boolean,
-      isCtrlKeyDown: Boolean,
-      isMetaKeyDown: Boolean,
-      isShiftKeyDown: Boolean,
-      movementPosition: Point,
-      button: MouseButton
-  ) extends MouseEvent
-  object MouseUp:
-    @nowarn("msg=deprecated")
-    def apply(position: Point): MouseUp =
-      MouseUp(
-        PointerId.unknown,
-        position = position,
-        buttons = Batch.empty,
-        isAltKeyDown = false,
-        isCtrlKeyDown = false,
-        isMetaKeyDown = false,
-        isShiftKeyDown = false,
-        movementPosition = Point.zero,
-        button = MouseButton.LeftMouseButton
-      )
-    @nowarn("msg=deprecated")
-    def apply(x: Int, y: Int): MouseUp =
-      MouseUp(
-        PointerId.unknown,
-        position = Point(x, y),
-        buttons = Batch.empty,
-        isAltKeyDown = false,
-        isCtrlKeyDown = false,
-        isMetaKeyDown = false,
-        isShiftKeyDown = false,
-        movementPosition = Point.zero,
-        button = MouseButton.LeftMouseButton
-      )
-    @nowarn("msg=deprecated")
-    def apply(x: Int, y: Int, button: MouseButton): MouseUp =
-      MouseUp(
-        PointerId.unknown,
-        position = Point(x, y),
-        buttons = Batch.empty,
-        isAltKeyDown = false,
-        isCtrlKeyDown = false,
-        isMetaKeyDown = false,
-        isShiftKeyDown = false,
-        movementPosition = Point.zero,
-        button = button
-      )
-    def unapply(e: MouseUp): Option[Point] =
       Option(e.position)
 
   /** The mouse button was released
@@ -285,65 +203,6 @@ object MouseEvent:
         button = button
       )
     def unapply(e: Up): Option[Point] =
-      Option(e.position)
-
-  /** The mouse button was pressed down.
-    * @param button
-    *   The button that was pressed down
-    */
-  @deprecated("Use `MouseEvents.Down` instead", "0.22.0")
-  final case class MouseDown(
-      pointerId: PointerId,
-      position: Point,
-      buttons: Batch[MouseButton],
-      isAltKeyDown: Boolean,
-      isCtrlKeyDown: Boolean,
-      isMetaKeyDown: Boolean,
-      isShiftKeyDown: Boolean,
-      movementPosition: Point,
-      button: MouseButton
-  ) extends MouseEvent
-  object MouseDown:
-    @nowarn("msg=deprecated")
-    def apply(position: Point): MouseDown =
-      MouseDown(
-        PointerId.unknown,
-        position = position,
-        buttons = Batch.empty,
-        isAltKeyDown = false,
-        isCtrlKeyDown = false,
-        isMetaKeyDown = false,
-        isShiftKeyDown = false,
-        movementPosition = Point.zero,
-        button = MouseButton.LeftMouseButton
-      )
-    @nowarn("msg=deprecated")
-    def apply(x: Int, y: Int): MouseDown =
-      MouseDown(
-        PointerId.unknown,
-        position = Point(x, y),
-        buttons = Batch.empty,
-        isAltKeyDown = false,
-        isCtrlKeyDown = false,
-        isMetaKeyDown = false,
-        isShiftKeyDown = false,
-        movementPosition = Point.zero,
-        button = MouseButton.LeftMouseButton
-      )
-    @nowarn("msg=deprecated")
-    def apply(x: Int, y: Int, button: MouseButton): MouseDown =
-      MouseDown(
-        PointerId.unknown,
-        position = Point(x, y),
-        buttons = Batch.empty,
-        isAltKeyDown = false,
-        isCtrlKeyDown = false,
-        isMetaKeyDown = false,
-        isShiftKeyDown = false,
-        movementPosition = Point.zero,
-        button = button
-      )
-    def unapply(e: MouseDown): Option[Point] =
       Option(e.position)
 
   /** The mouse button was pressed down
@@ -400,29 +259,13 @@ object MouseEvent:
   final case class Move(
       pointerId: PointerId,
       position: Point,
-      @deprecated("Use `InputState.mouse.buttons` instead", "0.22.0")
-      buttons: Batch[MouseButton],
-      @deprecated("Use `InputState.keyboard.isAltKeyDown` instead", "0.22.0")
-      isAltKeyDown: Boolean,
-      @deprecated("Use `InputState.keyboard.isCtrlKeyDown` instead", "0.22.0")
-      isCtrlKeyDown: Boolean,
-      @deprecated("Use `InputState.keyboard.isMetaKeyDown` instead", "0.22.0")
-      isMetaKeyDown: Boolean,
-      @deprecated("Use `InputState.keyboard.isShiftKeyDown` instead", "0.22.0")
-      isShiftKeyDown: Boolean,
       movementPosition: Point
   ) extends MouseEvent
   object Move:
-    @nowarn("msg=deprecated")
     def apply(x: Int, y: Int): Move =
       Move(
         PointerId.unknown,
         position = Point(x, y),
-        buttons = Batch.empty,
-        isAltKeyDown = false,
-        isCtrlKeyDown = false,
-        isMetaKeyDown = false,
-        isShiftKeyDown = false,
         movementPosition = Point.zero
       )
     def unapply(e: Move): Option[Point] =
@@ -440,16 +283,6 @@ object MouseEvent:
   final case class Enter(
       pointerId: PointerId,
       position: Point,
-      @deprecated("Use `InputState.mouse.buttons` instead", "0.22.0")
-      buttons: Batch[MouseButton],
-      @deprecated("Use `InputState.keyboard.isAltKeyDown` instead", "0.22.0")
-      isAltKeyDown: Boolean,
-      @deprecated("Use `InputState.keyboard.isCtrlKeyDown` instead", "0.22.0")
-      isCtrlKeyDown: Boolean,
-      @deprecated("Use `InputState.keyboard.isMetaKeyDown` instead", "0.22.0")
-      isMetaKeyDown: Boolean,
-      @deprecated("Use `InputState.keyboard.isShiftKeyDown` instead", "0.22.0")
-      isShiftKeyDown: Boolean,
       movementPosition: Point
   ) extends MouseEvent
   object Enter:
@@ -468,16 +301,6 @@ object MouseEvent:
   final case class Leave(
       pointerId: PointerId,
       position: Point,
-      @deprecated("Use `InputState.mouse.buttons` instead", "0.22.0")
-      buttons: Batch[MouseButton],
-      @deprecated("Use `InputState.keyboard.isAltKeyDown` instead", "0.22.0")
-      isAltKeyDown: Boolean,
-      @deprecated("Use `InputState.keyboard.isCtrlKeyDown` instead", "0.22.0")
-      isCtrlKeyDown: Boolean,
-      @deprecated("Use `InputState.keyboard.isMetaKeyDown` instead", "0.22.0")
-      isMetaKeyDown: Boolean,
-      @deprecated("Use `InputState.keyboard.isShiftKeyDown` instead", "0.22.0")
-      isShiftKeyDown: Boolean,
       movementPosition: Point
   ) extends MouseEvent
   object Leave:
@@ -501,63 +324,6 @@ object MouseEvent:
   object Cancel:
     def unapply(e: Cancel): Option[Point] =
       Option(e.position)
-
-  /** The mouse wheel was rotated a certain amount around an axis.
-    *
-    * @param deltaX
-    *   horizontal amount of pixels, pages or other unit, depending on delta mode, the X axis was scrolled
-    * @param deltaY
-    *   horizontal amount of pixels, pages or other unit, depending on delta mode, the Y axis was scrolled
-    * @param deltaZ
-    *   horizontal amount of pixels, pages or other unit, depending on delta mode, the Z axis was scrolled
-    */
-  @deprecated("Use `WheelEvent.Move` instead", "0.22.0")
-  final case class Wheel(
-      position: Point,
-      buttons: Batch[MouseButton],
-      isAltKeyDown: Boolean,
-      isCtrlKeyDown: Boolean,
-      isMetaKeyDown: Boolean,
-      isShiftKeyDown: Boolean,
-      movementPosition: Point,
-      deltaX: Double,
-      deltaY: Double,
-      deltaZ: Double
-  ) extends MouseEvent:
-    def pointerId = PointerId.unknown
-  object Wheel:
-    @nowarn("msg=deprecated")
-    def apply(x: Int, y: Int, deltaX: Double, deltaY: Double, deltaZ: Double): Wheel =
-      Wheel(
-        position = Point(x, y),
-        buttons = Batch.empty,
-        isAltKeyDown = false,
-        isCtrlKeyDown = false,
-        isMetaKeyDown = false,
-        isShiftKeyDown = false,
-        movementPosition = Point.zero,
-        deltaX = deltaX,
-        deltaY = deltaY,
-        deltaZ = deltaZ
-      )
-
-    @nowarn("msg=deprecated")
-    def apply(x: Int, y: Int, deltaY: Double): Wheel =
-      Wheel(
-        position = Point(x, y),
-        buttons = Batch.empty,
-        isAltKeyDown = false,
-        isCtrlKeyDown = false,
-        isMetaKeyDown = false,
-        isShiftKeyDown = false,
-        movementPosition = Point.zero,
-        deltaX = 0,
-        deltaY = deltaY,
-        deltaZ = 0
-      )
-    @nowarn("msg=deprecated")
-    def unapply(e: Wheel): Option[(Point, Double)] =
-      Option((e.position, e.deltaY))
 
 end MouseEvent
 
@@ -1017,7 +783,6 @@ object PenEvent:
       pressure: Double
   ) extends PenEvent
   object Move:
-    @nowarn("msg=deprecated")
     def apply(x: Int, y: Int): Move =
       Move(
         PointerId.unknown,
@@ -1100,90 +865,18 @@ end PenEvent
   */
 sealed trait PointerEvent extends PositionalInputEvent:
 
-  /** The width (magnitude on the X axis), of the contact geometry of the pointer relative to the screen
-    */
-  @deprecated("Being removed to simplify Input", "0.22.0")
-  def width: Int
-
-  /** The height (magnitude on the Y axis), of the contact geometry of the pointer relative to the screen
-    */
-  @deprecated("Being removed to simplify Input", "0.22.0")
-  def height: Int
-
-  /** The normalized pressure of the pointer input in the range 0 to 1, where 0 and 1 represent the minimum and maximum
-    * pressure the hardware is capable of detecting, respectively.
-    */
-  @deprecated("Use `TouchEvent.pressure` instead", "0.22.0")
-  def pressure: Double
-
-  /** The normalized tangential pressure of the pointer input (also known as barrel pressure or cylinder stress) in the
-    * range -1 to 1, where 0 is the neutral position of the control.
-    */
-  @deprecated("Being removed to simplify Input", "0.22.0")
-  def tangentialPressure: Double
-
-  /** The plane angle (in radians, in the range of -1.570796 to 1.570796 (-90 - 90 degrees)) between the Y–Z plane and
-    * the plane containing both the pointer (e.g. pen stylus) axis and the Y axis.
-    */
-  @deprecated("Being removed to simplify Input", "0.22.0")
-  def tiltX: Radians
-
-  /** The plane angle (in radians, in the range of -1.570796 to 1.570796 (-90 - 90 degrees)) between the X–Z plane and
-    * the plane containing both the pointer (e.g. pen stylus) axis and the X axis.
-    */
-  @deprecated("Being removed to simplify Input", "0.22.0")
-  def tiltY: Radians
-
-  /** The clockwise rotation of the pointer (e.g. pen stylus) around its major axis in degrees, with a value in the
-    * range 0 to 6.265732 (0 to 359 degrees)
-    */
-  @deprecated("Being removed to simplify Input", "0.22.0")
-  def twist: Radians
-
   /** Indicates the device type that caused the event (mouse, pen, touch, etc.)
     */
   def pointerType: PointerType
 
-  /** Indicates whether the pointer is considered primary - like first finger during multi-touch gesture
-    */
-  @deprecated("Being removed to simplify Input", "0.22.0")
-  def isPrimary: Boolean
-
-@nowarn("msg=deprecated")
 object PointerEvent:
   /** Pointing device is moved into canvas hit test boundaries. It's counterpart is [[Leave]].
     */
   final case class Enter(
       pointerId: PointerId,
       position: Point,
-      @deprecated("Use `InputState.mouse.buttons` instead", "0.22.0")
-      buttons: Batch[MouseButton],
-      @deprecated("Use `InputState.keyboard.isAltKeyDown` instead", "0.22.0")
-      isAltKeyDown: Boolean,
-      @deprecated("Use `InputState.keyboard.isCtrlKeyDown` instead", "0.22.0")
-      isCtrlKeyDown: Boolean,
-      @deprecated("Use `InputState.keyboard.isMetaKeyDown` instead", "0.22.0")
-      isMetaKeyDown: Boolean,
-      @deprecated("Use `InputState.keyboard.isShiftKeyDown` instead", "0.22.0")
-      isShiftKeyDown: Boolean,
       movementPosition: Point,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      width: Int,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      height: Int,
-      @deprecated("Use `TouchEvent.pressure` instead", "0.22.0")
-      pressure: Double,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      tangentialPressure: Double,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      tiltX: Radians,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      tiltY: Radians,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      twist: Radians,
-      pointerType: PointerType,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      isPrimary: Boolean
+      pointerType: PointerType
   ) extends PointerEvent
   object Enter:
     def unapply(e: Enter): Option[Point] =
@@ -1194,34 +887,8 @@ object PointerEvent:
   final case class Leave(
       pointerId: PointerId,
       position: Point,
-      @deprecated("Use `InputState.mouse.buttons` instead", "0.22.0")
-      buttons: Batch[MouseButton],
-      @deprecated("Use `InputState.keyboard.isAltKeyDown` instead", "0.22.0")
-      isAltKeyDown: Boolean,
-      @deprecated("Use `InputState.keyboard.isCtrlKeyDown` instead", "0.22.0")
-      isCtrlKeyDown: Boolean,
-      @deprecated("Use `InputState.keyboard.isMetaKeyDown` instead", "0.22.0")
-      isMetaKeyDown: Boolean,
-      @deprecated("Use `InputState.keyboard.isShiftKeyDown` instead", "0.22.0")
-      isShiftKeyDown: Boolean,
       movementPosition: Point,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      width: Int,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      height: Int,
-      @deprecated("Use `TouchEvent.pressure` instead", "0.22.0")
-      pressure: Double,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      tangentialPressure: Double,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      tiltX: Radians,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      tiltY: Radians,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      twist: Radians,
-      pointerType: PointerType,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      isPrimary: Boolean
+      pointerType: PointerType
   ) extends PointerEvent
   object Leave:
     def unapply(e: Leave): Option[Point] =
@@ -1232,34 +899,8 @@ object PointerEvent:
   final case class Down(
       pointerId: PointerId,
       position: Point,
-      @deprecated("Use `InputState.mouse.buttons` instead", "0.22.0")
-      buttons: Batch[MouseButton],
-      @deprecated("Use `InputState.keyboard.isAltKeyDown` instead", "0.22.0")
-      isAltKeyDown: Boolean,
-      @deprecated("Use `InputState.keyboard.isCtrlKeyDown` instead", "0.22.0")
-      isCtrlKeyDown: Boolean,
-      @deprecated("Use `InputState.keyboard.isMetaKeyDown` instead", "0.22.0")
-      isMetaKeyDown: Boolean,
-      @deprecated("Use `InputState.keyboard.isShiftKeyDown` instead", "0.22.0")
-      isShiftKeyDown: Boolean,
       movementPosition: Point,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      width: Int,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      height: Int,
-      @deprecated("Use `TouchEvent.pressure` instead", "0.22.0")
-      pressure: Double,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      tangentialPressure: Double,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      tiltX: Radians,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      tiltY: Radians,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      twist: Radians,
       pointerType: PointerType,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      isPrimary: Boolean,
       button: Option[MouseButton]
   ) extends PointerEvent
   object Down:
@@ -1278,27 +919,13 @@ object PointerEvent:
     def apply(x: Int, y: Int, button: MouseButton, pointerType: PointerType): Down =
       Down(Point(x, y), button, pointerType)
 
-    @nowarn("msg=deprecated")
     def apply(position: Point, button: MouseButton, pointerType: PointerType): Down =
       Down(
         pointerId = PointerId.unknown,
         position = position,
-        buttons = Batch(button),
-        isAltKeyDown = false,
-        isCtrlKeyDown = false,
-        isMetaKeyDown = false,
-        isShiftKeyDown = false,
         movementPosition = Point.zero,
         button = Some(button),
-        width = 0,
-        height = 0,
-        pressure = 0,
-        tangentialPressure = 0,
-        tiltX = Radians.zero,
-        tiltY = Radians.zero,
-        twist = Radians.zero,
-        pointerType = pointerType,
-        isPrimary = true
+        pointerType = pointerType
       )
 
     def unapply(e: Down): Option[Point] =
@@ -1309,34 +936,8 @@ object PointerEvent:
   final case class Up(
       pointerId: PointerId,
       position: Point,
-      @deprecated("Use `InputState.mouse.buttons` instead", "0.22.0")
-      buttons: Batch[MouseButton],
-      @deprecated("Use `InputState.keyboard.isAltKeyDown` instead", "0.22.0")
-      isAltKeyDown: Boolean,
-      @deprecated("Use `InputState.keyboard.isCtrlKeyDown` instead", "0.22.0")
-      isCtrlKeyDown: Boolean,
-      @deprecated("Use `InputState.keyboard.isMetaKeyDown` instead", "0.22.0")
-      isMetaKeyDown: Boolean,
-      @deprecated("Use `InputState.keyboard.isShiftKeyDown` instead", "0.22.0")
-      isShiftKeyDown: Boolean,
       movementPosition: Point,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      width: Int,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      height: Int,
-      @deprecated("Use `TouchEvent.pressure` instead", "0.22.0")
-      pressure: Double,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      tangentialPressure: Double,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      tiltX: Radians,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      tiltY: Radians,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      twist: Radians,
       pointerType: PointerType,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      isPrimary: Boolean,
       button: Option[MouseButton]
   ) extends PointerEvent
   object Up:
@@ -1355,27 +956,13 @@ object PointerEvent:
     def apply(x: Int, y: Int, button: MouseButton, pointerType: PointerType): Up =
       Up(Point(x, y), button, pointerType)
 
-    @nowarn("msg=deprecated")
     def apply(position: Point, button: MouseButton, pointerType: PointerType): Up =
       Up(
         pointerId = PointerId.unknown,
         position = position,
-        buttons = Batch.empty,
-        isAltKeyDown = false,
-        isCtrlKeyDown = false,
-        isMetaKeyDown = false,
-        isShiftKeyDown = false,
         movementPosition = Point.zero,
         button = Some(button),
-        width = 0,
-        height = 0,
-        pressure = 0,
-        tangentialPressure = 0,
-        tiltX = Radians.zero,
-        tiltY = Radians.zero,
-        twist = Radians.zero,
-        pointerType = pointerType,
-        isPrimary = true
+        pointerType = pointerType
       )
 
     def unapply(e: Up): Option[Point] =
@@ -1385,34 +972,8 @@ object PointerEvent:
   final case class Click(
       pointerId: PointerId,
       position: Point,
-      @deprecated("Use `InputState.mouse.buttons` instead", "0.22.0")
-      buttons: Batch[MouseButton],
-      @deprecated("Use `InputState.keyboard.isAltKeyDown` instead", "0.22.0")
-      isAltKeyDown: Boolean,
-      @deprecated("Use `InputState.keyboard.isCtrlKeyDown` instead", "0.22.0")
-      isCtrlKeyDown: Boolean,
-      @deprecated("Use `InputState.keyboard.isMetaKeyDown` instead", "0.22.0")
-      isMetaKeyDown: Boolean,
-      @deprecated("Use `InputState.keyboard.isShiftKeyDown` instead", "0.22.0")
-      isShiftKeyDown: Boolean,
       movementPosition: Point,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      width: Int,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      height: Int,
-      @deprecated("Use `TouchEvent.pressure` instead", "0.22.0")
-      pressure: Double,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      tangentialPressure: Double,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      tiltX: Radians,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      tiltY: Radians,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      twist: Radians,
       pointerType: PointerType,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      isPrimary: Boolean,
       button: Option[MouseButton]
   ) extends PointerEvent
   object Click:
@@ -1431,27 +992,13 @@ object PointerEvent:
     def apply(x: Int, y: Int, button: MouseButton, pointerType: PointerType): Click =
       Click(Point(x, y), button, pointerType)
 
-    @nowarn("msg=deprecated")
     def apply(position: Point, button: MouseButton, pointerType: PointerType): Click =
       Click(
         pointerId = PointerId.unknown,
         position = position,
-        buttons = Batch.empty,
-        isAltKeyDown = false,
-        isCtrlKeyDown = false,
-        isMetaKeyDown = false,
-        isShiftKeyDown = false,
         movementPosition = Point.zero,
         button = Some(button),
-        width = 0,
-        height = 0,
-        pressure = 0,
-        tangentialPressure = 0,
-        tiltX = Radians.zero,
-        tiltY = Radians.zero,
-        twist = Radians.zero,
-        pointerType = pointerType,
-        isPrimary = true
+        pointerType = pointerType
       )
     def unapply(e: Click): Option[Point] =
       Option(e.position)
@@ -1461,34 +1008,8 @@ object PointerEvent:
   final case class Move(
       pointerId: PointerId,
       position: Point,
-      @deprecated("Use `InputState.mouse.buttons` instead", "0.22.0")
-      buttons: Batch[MouseButton],
-      @deprecated("Use `InputState.keyboard.isAltKeyDown` instead", "0.22.0")
-      isAltKeyDown: Boolean,
-      @deprecated("Use `InputState.keyboard.isCtrlKeyDown` instead", "0.22.0")
-      isCtrlKeyDown: Boolean,
-      @deprecated("Use `InputState.keyboard.isMetaKeyDown` instead", "0.22.0")
-      isMetaKeyDown: Boolean,
-      @deprecated("Use `InputState.keyboard.isShiftKeyDown` instead", "0.22.0")
-      isShiftKeyDown: Boolean,
       movementPosition: Point,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      width: Int,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      height: Int,
-      @deprecated("Use `TouchEvent.pressure` instead", "0.22.0")
-      pressure: Double,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      tangentialPressure: Double,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      tiltX: Radians,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      tiltY: Radians,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      twist: Radians,
-      pointerType: PointerType,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      isPrimary: Boolean
+      pointerType: PointerType
   ) extends PointerEvent
   object Move:
     def apply(position: Point): Move =
@@ -1498,26 +1019,12 @@ object PointerEvent:
     def apply(x: Int, y: Int, pointerType: PointerType): Move =
       Move(Point(x, y), pointerType)
 
-    @nowarn("msg=deprecated")
     def apply(position: Point, pointerType: PointerType): Move =
       Move(
         pointerId = PointerId.unknown,
         position = position,
-        buttons = Batch.empty,
-        isAltKeyDown = false,
-        isCtrlKeyDown = false,
-        isMetaKeyDown = false,
-        isShiftKeyDown = false,
         movementPosition = Point.zero,
-        width = 0,
-        height = 0,
-        pressure = 0,
-        tangentialPressure = 0,
-        tiltX = Radians.zero,
-        tiltY = Radians.zero,
-        twist = Radians.zero,
-        pointerType = pointerType,
-        isPrimary = true
+        pointerType = pointerType
       )
 
     def unapply(e: Move): Option[Point] =
@@ -1532,81 +1039,11 @@ object PointerEvent:
   final case class Cancel(
       pointerId: PointerId,
       position: Point,
-      @deprecated("Use `InputState.mouse.buttons` instead", "0.22.0")
-      buttons: Batch[MouseButton],
-      @deprecated("Use `InputState.keyboard.isAltKeyDown` instead", "0.22.0")
-      isAltKeyDown: Boolean,
-      @deprecated("Use `InputState.keyboard.isCtrlKeyDown` instead", "0.22.0")
-      isCtrlKeyDown: Boolean,
-      @deprecated("Use `InputState.keyboard.isMetaKeyDown` instead", "0.22.0")
-      isMetaKeyDown: Boolean,
-      @deprecated("Use `InputState.keyboard.isShiftKeyDown` instead", "0.22.0")
-      isShiftKeyDown: Boolean,
       movementPosition: Point,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      width: Int,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      height: Int,
-      @deprecated("Use `TouchEvent.pressure` instead", "0.22.0")
-      pressure: Double,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      tangentialPressure: Double,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      tiltX: Radians,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      tiltY: Radians,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      twist: Radians,
-      pointerType: PointerType,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      isPrimary: Boolean
+      pointerType: PointerType
   ) extends PointerEvent
   object Cancel:
     def unapply(e: Cancel): Option[Point] =
-      Option(e.position)
-
-  /** The pointer is no longer sending events because:
-    *   - the pointing device is moved out of the hit boundaries
-    *   - the PointerUp event was fired on a device that doesn't support hover
-    *   - after firing the PointerCancel event
-    *   - when a pen stylus leaves the hover range detectable by the digitizer.
-    */
-
-  @deprecated("Use `PointerEvent.Leave` instead", "0.22.0")
-  final case class Out(
-      pointerId: PointerId,
-      position: Point,
-      @deprecated("Use `InputState.mouse.buttons` instead", "0.22.0")
-      buttons: Batch[MouseButton],
-      @deprecated("Use `InputState.keyboard.isAltKeyDown` instead", "0.22.0")
-      isAltKeyDown: Boolean,
-      @deprecated("Use `InputState.keyboard.isCtrlKeyDown` instead", "0.22.0")
-      isCtrlKeyDown: Boolean,
-      @deprecated("Use `InputState.keyboard.isMetaKeyDown` instead", "0.22.0")
-      isMetaKeyDown: Boolean,
-      @deprecated("Use `InputState.keyboard.isShiftKeyDown` instead", "0.22.0")
-      isShiftKeyDown: Boolean,
-      movementPosition: Point,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      width: Int,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      height: Int,
-      @deprecated("Use `TouchEvent.pressure` instead", "0.22.0")
-      pressure: Double,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      tangentialPressure: Double,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      tiltX: Radians,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      tiltY: Radians,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      twist: Radians,
-      pointerType: PointerType,
-      @deprecated("Being removed to simplify Input", "0.22.0")
-      isPrimary: Boolean
-  ) extends PointerEvent
-  object Out:
-    def unapply(e: Out): Option[Point] =
       Option(e.position)
 
 /** Represents all keyboard events

--- a/indigo-core/src/indigo/core/events/InputState.scala
+++ b/indigo-core/src/indigo/core/events/InputState.scala
@@ -10,8 +10,6 @@ import indigo.core.input.Wheel
 import indigoengine.shared.collections.Batch
 import indigoengine.shared.datatypes.Millis
 
-import scala.annotation.nowarn
-
 /** Holds a snapshot of the states of the various input types as they were entering this frame.
   *
   * @param mouse
@@ -77,8 +75,7 @@ object InputState {
       gamepadState: Gamepad,
       time: Millis
   ): InputState =
-    @nowarn("msg=deprecated")
-    val state = InputState(
+    InputState(
       previous.mouse.calculateNext(events.collect { case e: MouseEvent => e }),
       Keyboard.calculateNext(previous.keyboard, events.collect { case e: KeyboardEvent => e }),
       gamepadState,
@@ -87,6 +84,4 @@ object InputState {
       previous.touch.calculateNext(events.collect { case e: TouchEvent => e }),
       previous.pointer.calculateNext(events.collect { case e: PointerEvent => e }, time)
     )
-
-    state
 }

--- a/indigo-core/src/indigo/core/events/MouseWheel.scala
+++ b/indigo-core/src/indigo/core/events/MouseWheel.scala
@@ -1,7 +1,0 @@
-package indigo.core.events
-
-import scala.annotation.nowarn
-
-@deprecated("Use `WheelDirection` instead", "0.22.0")
-enum MouseWheel derives CanEqual:
-  @nowarn("msg=deprecated") case ScrollUp, ScrollDown

--- a/indigo-core/src/indigo/core/input/MouseState.scala
+++ b/indigo-core/src/indigo/core/input/MouseState.scala
@@ -4,22 +4,13 @@ import indigo.core.datatypes.Point
 import indigo.core.datatypes.Rectangle
 import indigo.core.events.MouseButton
 import indigo.core.events.MouseEvent
-import indigo.core.events.MouseWheel
 import indigo.core.events.PointerId
-import indigo.core.events.PointerType
 import indigoengine.shared.collections.Batch
 
-import scala.annotation.nowarn
-
-@nowarn("msg=deprecated")
 final case class MouseState(
-    val instances: Batch[Mouse],
-    @deprecated("Use `InputState.Wheel` instead", "0.22.0")
-    val wheelEvents: Batch[MouseEvent.Wheel]
+    val instances: Batch[Mouse]
 ) extends ButtonInputState
     with PositionalInputState {
-  @deprecated("This will soon be removed", "0.22.0")
-  val pointerType: Option[PointerType] = Some(PointerType.Mouse)
 
   /** The primary mouse instance
     */
@@ -86,9 +77,6 @@ final case class MouseState(
     */
   def wasDownAt(x: Int, y: Int): Boolean = wasDownAt(Point(x, y))
 
-  @deprecated("Use `MouseState.wasButtonUpWithin` instead", "0.22.0")
-  def wasUpWithin(bounds: Rectangle, mouseButton: MouseButton): Boolean = wasButtonUpWithin(bounds, mouseButton)
-
   /** Whether the left mouse button was up within the specified bounds in this frame
     *
     * @param bounds
@@ -112,9 +100,6 @@ final case class MouseState(
   def wasUpWithin(x: Int, y: Int, width: Int, height: Int): Boolean = wasUpWithin(
     Rectangle(x, y, width, height)
   )
-
-  @deprecated("Use `MouseState.wasButtonDownWithin` instead", "0.22.0")
-  def wasDownWithin(bounds: Rectangle, mouseButton: MouseButton): Boolean = wasButtonDownWithin(bounds, mouseButton)
 
   /** Whether the left mouse button was down within the specified bounds in this frame
     *
@@ -140,19 +125,6 @@ final case class MouseState(
     Rectangle(x, y, width, height)
   )
 
-  @deprecated("Use `InputState.Wheel` instead", "0.22.0")
-  lazy val scrolled: Option[MouseWheel] =
-
-    @nowarn("msg=deprecated")
-    val amount = wheelEvents.foldLeft(0d) { case (acc, e) =>
-      acc + e.deltaY
-    }
-
-    if amount == 0 then Option.empty[MouseWheel]
-    else if amount < 0 then Some(MouseWheel.ScrollUp)
-    else Some(MouseWheel.ScrollDown)
-
-  @nowarn("msg=deprecated")
   def calculateNext(events: Batch[MouseEvent]) =
     val newInstances = events.foldLeft(
       // Reset the frame state for all mouse instances
@@ -182,19 +154,16 @@ final case class MouseState(
           case _: MouseEvent.Leave => instance
           // We should never reach here
           case _: MouseEvent.Cancel => instance
-          // Deprecated events
-          case _: (MouseEvent.MouseDown | MouseEvent.MouseUp | MouseEvent.Wheel) => instance
         }
 
         instances.filterNot(_.pointerId == event.pointerId) :+ newInstance
     )
 
-    this.copy(instances = newInstances, wheelEvents = events.collect { case e: MouseEvent.Wheel => e })
+    this.copy(instances = newInstances)
 }
 
 object MouseState:
-  @nowarn("msg=deprecated")
-  val default: MouseState = MouseState(Batch.empty, Batch.empty)
+  val default: MouseState = MouseState(Batch.empty)
 
   private def getOrCreate(id: PointerId, instances: Batch[Mouse]) =
     instances

--- a/indigo-core/src/indigo/core/input/PointerState.scala
+++ b/indigo-core/src/indigo/core/input/PointerState.scala
@@ -8,8 +8,6 @@ import indigo.core.events.PointerType
 import indigoengine.shared.collections.Batch
 import indigoengine.shared.datatypes.Millis
 
-import scala.annotation.nowarn
-
 final case class PointerState(instances: Batch[Pointer]) extends ButtonInputState with PositionalInputState {
 
   /** The position of the most recently updated pointer instance, or None if no instances exist
@@ -52,7 +50,6 @@ final case class PointerState(instances: Batch[Pointer]) extends ButtonInputStat
     */
   val isDown = isDownAt.isEmpty == false
 
-  @nowarn("msg=deprecated")
   def calculateNext(events: Batch[PointerEvent], time: Millis) =
     val newInstances = events.foldLeft(
       // Reset the frame state for all instances
@@ -101,8 +98,6 @@ final case class PointerState(instances: Batch[Pointer]) extends ButtonInputStat
           case _: PointerEvent.Leave => instance
           // We should never reach here
           case _: PointerEvent.Cancel => instance
-          // Deprecated
-          case _: PointerEvent.Out => instance
         }
 
         instances.filterNot(_.pointerId == event.pointerId) :+ newInstance

--- a/indigo-core/src/indigo/core/input/PositionalInputState.scala
+++ b/indigo-core/src/indigo/core/input/PositionalInputState.scala
@@ -61,16 +61,3 @@ trait PositionalInputState:
     */
   def wasAt(x: Int, y: Int): Boolean =
     wasAt(Point(x, y))
-
-  @deprecated("Use `wasAt` instead", "0.22.0")
-  def wasPositionAt(position: Point): Boolean = wasAt(position)
-
-  @deprecated("Use `wasAt` instead", "0.22.0")
-  def wasPositionAt(x: Int, y: Int): Boolean = wasAt(Point(x, y))
-
-  @deprecated("Use `wasWithin` instead", "0.22.0")
-  def wasPositionWithin(bounds: Rectangle): Boolean = wasWithin(bounds)
-
-  @deprecated("Use `wasWithin` instead", "0.22.0")
-  def wasPositionWithin(x: Int, y: Int, width: Int, height: Int): Boolean =
-    wasWithin(Rectangle(x, y, width, height))

--- a/indigo/src-js/indigo/internal/WorldEventWatcherImpls.scala
+++ b/indigo/src-js/indigo/internal/WorldEventWatcherImpls.scala
@@ -22,7 +22,6 @@ final class WorldEventWatcherImpls(canvas: html.Canvas):
 
   def onPointerMove(e: dom.PointerEvent): Option[Msg.WorldEvents] =
     val position         = e.position(canvas)
-    val buttons          = e.indigoButtons
     val movementPosition = e.movementPosition
     val pointerType      = e.toPointerType
 
@@ -30,21 +29,8 @@ final class WorldEventWatcherImpls(canvas: html.Canvas):
       PointerEvent.Move(
         PointerId(e.pointerId),
         position,
-        buttons,
-        e.altKey,
-        e.ctrlKey,
-        e.metaKey,
-        e.shiftKey,
         movementPosition,
-        e.width.toInt,
-        e.height.toInt,
-        e.pressure,
-        e.tangentialPressure,
-        Radians.fromDegrees(Degrees(e.tiltX)),
-        Radians.fromDegrees(Degrees(e.tiltY)),
-        Radians.fromDegrees(Degrees(e.twist)),
-        pointerType,
-        e.isPrimary
+        pointerType
       )
 
     val events =
@@ -54,11 +40,6 @@ final class WorldEventWatcherImpls(canvas: html.Canvas):
             MouseEvent.Move(
               PointerId(e.pointerId),
               position,
-              buttons,
-              e.altKey,
-              e.ctrlKey,
-              e.metaKey,
-              e.shiftKey,
               movementPosition
             )
           )
@@ -93,7 +74,6 @@ final class WorldEventWatcherImpls(canvas: html.Canvas):
 
   def onPointerEnter(e: dom.PointerEvent): Option[Msg.WorldEvents] =
     val position         = e.position(canvas)
-    val buttons          = e.indigoButtons
     val movementPosition = e.movementPosition
     val pointerType      = e.toPointerType
 
@@ -101,36 +81,17 @@ final class WorldEventWatcherImpls(canvas: html.Canvas):
       PointerEvent.Enter(
         PointerId(e.pointerId),
         position,
-        buttons,
-        e.altKey,
-        e.ctrlKey,
-        e.metaKey,
-        e.shiftKey,
         movementPosition,
-        e.width.toInt,
-        e.height.toInt,
-        e.pressure,
-        e.tangentialPressure,
-        Radians.fromDegrees(Degrees(e.tiltX)),
-        Radians.fromDegrees(Degrees(e.tiltY)),
-        Radians.fromDegrees(Degrees(e.twist)),
-        pointerType,
-        e.isPrimary
+        pointerType
       )
 
     val events =
       pointerType match
         case PointerType.Mouse =>
-          @nowarn("msg=deprecated")
           val mouseEnter =
             MouseEvent.Enter(
               PointerId(e.pointerId),
               position,
-              buttons,
-              e.altKey,
-              e.ctrlKey,
-              e.metaKey,
-              e.shiftKey,
               movementPosition
             )
 
@@ -160,11 +121,10 @@ final class WorldEventWatcherImpls(canvas: html.Canvas):
         case PointerType.Unknown =>
           Batch.empty
 
-    Option(Msg.WorldEvents(Batch(enterEvent) ++ events))
+    Option(Msg.WorldEvents(enterEvent +: events))
 
   def onPointerLeave(e: dom.PointerEvent): Option[Msg.WorldEvents] =
     val position         = e.position(canvas)
-    val buttons          = e.indigoButtons
     val movementPosition = e.movementPosition
     val pointerType      = e.toPointerType
 
@@ -172,58 +132,17 @@ final class WorldEventWatcherImpls(canvas: html.Canvas):
       PointerEvent.Leave(
         PointerId(e.pointerId),
         position,
-        buttons,
-        e.altKey,
-        e.ctrlKey,
-        e.metaKey,
-        e.shiftKey,
         movementPosition,
-        e.width.toInt,
-        e.height.toInt,
-        e.pressure,
-        e.tangentialPressure,
-        Radians.fromDegrees(Degrees(e.tiltX)),
-        Radians.fromDegrees(Degrees(e.tiltY)),
-        Radians.fromDegrees(Degrees(e.twist)),
-        pointerType,
-        e.isPrimary
-      )
-
-    @nowarn("msg=deprecated")
-    val outEvent =
-      PointerEvent.Out(
-        PointerId(e.pointerId),
-        position,
-        buttons,
-        e.altKey,
-        e.ctrlKey,
-        e.metaKey,
-        e.shiftKey,
-        movementPosition,
-        e.width.toInt,
-        e.height.toInt,
-        e.pressure,
-        e.tangentialPressure,
-        Radians.fromDegrees(Degrees(e.tiltX)),
-        Radians.fromDegrees(Degrees(e.tiltY)),
-        Radians.fromDegrees(Degrees(e.twist)),
-        pointerType,
-        e.isPrimary
+        pointerType
       )
 
     val events =
       pointerType match
         case PointerType.Mouse =>
-          @nowarn("msg=deprecated")
           val mouseLeave =
             MouseEvent.Leave(
               PointerId(e.pointerId),
               position,
-              buttons,
-              e.altKey,
-              e.ctrlKey,
-              e.metaKey,
-              e.shiftKey,
               movementPosition
             )
 
@@ -253,12 +172,11 @@ final class WorldEventWatcherImpls(canvas: html.Canvas):
         case PointerType.Unknown =>
           Batch.empty
 
-    Option(Msg.WorldEvents(Batch(leaveEvent, outEvent) ++ events))
+    Option(Msg.WorldEvents(leaveEvent +: events))
 
   def onPointerDown(e: dom.PointerEvent): Option[Msg.WorldEvents] =
     val position         = e.position(canvas)
     val pointerType      = e.toPointerType
-    val buttons          = e.indigoButtons
     val movementPosition = e.movementPosition
 
     // A pen being touched to a touchpad, or a finger touching a screen both result in a left button being registered
@@ -276,21 +194,8 @@ final class WorldEventWatcherImpls(canvas: html.Canvas):
       PointerEvent.Down(
         PointerId(e.pointerId),
         position,
-        buttons,
-        e.altKey,
-        e.ctrlKey,
-        e.metaKey,
-        e.shiftKey,
         movementPosition,
-        e.width.toInt,
-        e.height.toInt,
-        e.pressure,
-        e.tangentialPressure,
-        Radians.fromDegrees(Degrees(e.tiltX)),
-        Radians.fromDegrees(Degrees(e.tiltY)),
-        Radians.fromDegrees(Degrees(e.twist)),
         pointerType,
-        e.isPrimary,
         MouseButton.fromOrdinalOpt(button)
       )
 
@@ -299,22 +204,7 @@ final class WorldEventWatcherImpls(canvas: html.Canvas):
         case PointerType.Mouse =>
           MouseButton.fromOrdinalOpt(button) match
             case Some(btn) =>
-              @nowarn("msg=deprecated")
-              val mouseDown =
-                MouseEvent.MouseDown(
-                  PointerId(e.pointerId),
-                  position,
-                  buttons,
-                  e.altKey,
-                  e.ctrlKey,
-                  e.metaKey,
-                  e.shiftKey,
-                  movementPosition,
-                  btn
-                )
-
               Batch(
-                mouseDown,
                 MouseEvent.Down(
                   PointerId(e.pointerId),
                   position,
@@ -358,7 +248,6 @@ final class WorldEventWatcherImpls(canvas: html.Canvas):
   def onPointerUp(clickTimeMs: Long)(e: dom.PointerEvent): Option[Msg.WorldEvents] =
     val position         = e.position(canvas)
     val pointerType      = e.toPointerType
-    val buttons          = e.indigoButtons
     val movementPosition = e.movementPosition
 
     val button = if pointerType == PointerType.Mouse then e.button else e.button - 1
@@ -371,21 +260,8 @@ final class WorldEventWatcherImpls(canvas: html.Canvas):
             PointerEvent.Click(
               PointerId(e.pointerId),
               position,
-              buttons,
-              e.altKey,
-              e.ctrlKey,
-              e.metaKey,
-              e.shiftKey,
               movementPosition,
-              e.width.toInt,
-              e.height.toInt,
-              e.pressure,
-              e.tangentialPressure,
-              Radians.fromDegrees(Degrees(e.tiltX)),
-              Radians.fromDegrees(Degrees(e.tiltY)),
-              Radians.fromDegrees(Degrees(e.twist)),
               pointerType,
-              e.isPrimary,
               btn
             )
 
@@ -396,11 +272,6 @@ final class WorldEventWatcherImpls(canvas: html.Canvas):
                   MouseEvent.Click(
                     PointerId(e.pointerId),
                     position,
-                    buttons,
-                    e.altKey,
-                    e.ctrlKey,
-                    e.metaKey,
-                    e.shiftKey,
                     movementPosition,
                     btn.get
                   )
@@ -431,7 +302,7 @@ final class WorldEventWatcherImpls(canvas: html.Canvas):
               case PointerType.Unknown | PointerType.Mouse =>
                 Batch.empty
 
-          Batch(click) ++ typed
+          click +: typed
 
         case _ =>
           Batch.empty
@@ -447,21 +318,8 @@ final class WorldEventWatcherImpls(canvas: html.Canvas):
       PointerEvent.Up(
         PointerId(e.pointerId),
         position,
-        buttons,
-        e.altKey,
-        e.ctrlKey,
-        e.metaKey,
-        e.shiftKey,
         movementPosition,
-        e.width.toInt,
-        e.height.toInt,
-        e.pressure,
-        e.tangentialPressure,
-        Radians.fromDegrees(Degrees(e.tiltX)),
-        Radians.fromDegrees(Degrees(e.tiltY)),
-        Radians.fromDegrees(Degrees(e.twist)),
         pointerType,
-        e.isPrimary,
         MouseButton.fromOrdinalOpt(button)
       )
 
@@ -470,22 +328,7 @@ final class WorldEventWatcherImpls(canvas: html.Canvas):
         case PointerType.Mouse =>
           MouseButton.fromOrdinalOpt(e.button) match
             case Some(btn) =>
-              @nowarn("msg=deprecated")
-              val mouseUp =
-                MouseEvent.MouseUp(
-                  PointerId(e.pointerId),
-                  position,
-                  buttons,
-                  e.altKey,
-                  e.ctrlKey,
-                  e.metaKey,
-                  e.shiftKey,
-                  movementPosition,
-                  btn
-                )
-
               Batch(
-                mouseUp,
                 MouseEvent.Up(
                   PointerId(e.pointerId),
                   position,
@@ -528,7 +371,6 @@ final class WorldEventWatcherImpls(canvas: html.Canvas):
 
   def onPointerCancel(e: dom.PointerEvent): Option[Msg.WorldEvents] =
     val position         = e.position(canvas)
-    val buttons          = e.indigoButtons
     val movementPosition = e.movementPosition
     val pointerType      = e.toPointerType
 
@@ -536,21 +378,8 @@ final class WorldEventWatcherImpls(canvas: html.Canvas):
       PointerEvent.Cancel(
         PointerId(e.pointerId),
         position,
-        buttons,
-        e.altKey,
-        e.ctrlKey,
-        e.metaKey,
-        e.shiftKey,
         movementPosition,
-        e.width.toInt,
-        e.height.toInt,
-        e.pressure,
-        e.tangentialPressure,
-        Radians.fromDegrees(Degrees(e.tiltX)),
-        Radians.fromDegrees(Degrees(e.tiltY)),
-        Radians.fromDegrees(Degrees(e.twist)),
-        pointerType,
-        e.isPrimary
+        pointerType
       )
 
     val events =
@@ -633,25 +462,6 @@ final class WorldEventWatcherImpls(canvas: html.Canvas):
     )
 
   def onWheel(e: dom.WheelEvent): Option[Msg.WorldEvents] =
-    val position         = e.position(canvas)
-    val buttons          = e.indigoButtons
-    val movementPosition = e.movementPosition
-
-    @nowarn("msg=deprecated")
-    val wheel =
-      MouseEvent.Wheel(
-        position,
-        buttons,
-        e.altKey,
-        e.ctrlKey,
-        e.metaKey,
-        e.shiftKey,
-        movementPosition,
-        e.deltaX,
-        e.deltaY,
-        e.deltaZ
-      )
-
     val deltaMode =
       e.deltaMode match
         case dom.WheelEvent.DOM_DELTA_PIXEL => WheelEvent.DeltaMode.Pixel
@@ -668,7 +478,7 @@ final class WorldEventWatcherImpls(canvas: html.Canvas):
       val zs = if e.deltaZ != 0 then Batch(WheelEvent.Depth(e.deltaZ, deltaMode)) else Batch.empty
       xs ++ ys ++ zs
 
-    Option(Msg.WorldEvents(Batch(wheel, move) ++ axisEvents))
+    Option(Msg.WorldEvents(move +: axisEvents))
 
   @nowarn("msg=unused")
   def onCanvasFocus(e: dom.FocusEvent): Option[Msg.WorldEvents] =

--- a/indigo/src/indigo/package.scala
+++ b/indigo/src/indigo/package.scala
@@ -202,11 +202,6 @@ object aliases:
   type MouseButton = indigo.core.events.MouseButton
   val MouseButton: indigo.core.events.MouseButton.type = indigo.core.events.MouseButton
 
-  @deprecated("Use `ScrollDirection` instead", "0.22.0")
-  type MouseWheel = indigo.core.events.MouseWheel
-  @deprecated("Use `ScrollDirection` instead", "0.22.0")
-  val MouseWheel: indigo.core.events.MouseWheel.type = indigo.core.events.MouseWheel
-
   type TouchState = indigo.core.input.TouchState
   val TouchState: indigo.core.input.TouchState.type = indigo.core.input.TouchState
 


### PR DESCRIPTION
This PR removes all features that were deprecated in 0.22.0

The following changes have been made: 
- InputEvent.scala
  - MouseEvent.MouseUp, MouseEvent.MouseDown, MouseEvent.Wheel case classes
  - Deprecated fields on Click/Move/Enter/Leave (buttons, isAltKeyDown, isCtrlKeyDown, isMetaKeyDown, isShiftKeyDown)
  - PointerEvent trait members: width, height, pressure, tangentialPressure, tiltX, tiltY, twist, isPrimary
  - Same deprecated fields on PointerEvent.Enter/Leave/Down/Up/Click/Move/Cancel
  - PointerEvent.Out case class
- MouseWheel.scala — whole enum was deprecated
- MouseState.scala — wheelEvents, pointerType, wasUpWithin, wasDownWithin, scrolled
- PositionalInputState.scala — wasPositionAt (×2), wasPositionWithin (×2)
- package.scala — MouseWheel type/val aliases