### PR TITLE
Layer compacting improvements

### DIFF
--- a/indigo-core/src/indigo/core/render/Magnification.scala
+++ b/indigo-core/src/indigo/core/render/Magnification.scala
@@ -36,3 +36,5 @@ object Magnification:
     def increase: Magnification = clampToRange(m.toInt + 1)
     def decrease: Magnification = clampToRange(m.toInt - 1)
     def toInt: Int              = m
+
+  given CanEqual[Magnification, Magnification] = CanEqual.derived

--- a/indigo-render-pipeline/src/indigo/render/pipeline/sceneprocessing/utils/CompactLayers.scala
+++ b/indigo-render-pipeline/src/indigo/render/pipeline/sceneprocessing/utils/CompactLayers.scala
@@ -9,9 +9,13 @@ import scala.annotation.tailrec
 
 object CompactLayers:
 
-  /** Compact layers by squashing layers that have the same properties.
+  /** Optimise the number of full screen render composites we need to perform by collapsing the layer tree structure
+    * into a minimal number of 'layers', broadly in two phases:
     *
-    * Note: Layer Entries are already compacted because they get merged by key in an earlier step.
+    *   1. Layer Entries were previously merged togther by key during scene composition, that is the purpose of layer
+    *      keys. Here we discard layer keys as we no longer need them, and flatten layer entry groups where the rules
+    *      allow, i.e. magnification levels are the same
+    *   2. Unwraps layer stacks and compacts content layers by squashing those that have the same properties.
     */
   def compactLayers(layerEntries: Batch[LayerEntry]): Batch[(Batch[Layer.Content], Magnification)] =
     // Step 1: Unwrap the stacks, no compacting

--- a/indigo-render-pipeline/src/indigo/render/pipeline/sceneprocessing/utils/CompactLayers.scala
+++ b/indigo-render-pipeline/src/indigo/render/pipeline/sceneprocessing/utils/CompactLayers.scala
@@ -11,21 +11,58 @@ object CompactLayers:
 
   /** Compact layers by squashing layers that have the same properties.
     *
-    * Note: Layer Entries are already compacted because they get merged by key in an earler step.
+    * Note: Layer Entries are already compacted because they get merged by key in an earlier step.
     */
   def compactLayers(layerEntries: Batch[LayerEntry]): Batch[(Batch[Layer.Content], Magnification)] =
-    layerEntries.flatMap {
-      case LayerEntry(_, _, cfg) if cfg.isHidden =>
-        Batch.empty
+    // Step 1: Unwrap the stacks, no compacting
+    val step1 =
+      layerEntries.flatMap {
+        case LayerEntry(_, _, cfg) if cfg.isHidden =>
+          Batch.empty
 
-      case LayerEntry(_, layer: Layer.Content, cfg) =>
-        Batch((Batch(layer), cfg.giveMagnification))
+        case LayerEntry(_, layer: Layer.Content, cfg) =>
+          Batch((Batch(layer), cfg.giveMagnification))
 
-      case LayerEntry(_, stack: Layer.Stack, cfg) =>
-        val ls = compactContentLayers(stack.toBatch)
-        if ls.isEmpty then Batch.empty
-        else Batch((ls, cfg.giveMagnification))
-    }
+        case LayerEntry(_, stack: Layer.Stack, cfg) =>
+          val ls = stack.toBatch
+          if ls.isEmpty then Batch.empty
+          else Batch((ls, cfg.giveMagnification))
+      }
+
+    // Step 2: Squash the outer batch, where the magnification is the same.
+    val step2 =
+      compactByMagnification(step1)
+
+    // Step 3: Compact Content layers within each sub-group.
+    val step3 =
+      step2.map { case (layers, mag) => (compactContentLayers(layers), mag) }
+
+    step3
+
+  def compactByMagnification(
+      entries: Batch[(Batch[Layer.Content], Magnification)]
+  ): Batch[(Batch[Layer.Content], Magnification)] =
+    @tailrec
+    def rec(
+        remaining: Batch[(Batch[Layer.Content], Magnification)],
+        currentLayers: Batch[Layer.Content],
+        currentMagnification: Magnification,
+        acc: Batch[(Batch[Layer.Content], Magnification)]
+    ): Batch[(Batch[Layer.Content], Magnification)] =
+      if remaining.length == 0 then acc :+ (currentLayers, currentMagnification)
+      else
+        val head = remaining.head
+        val tail = remaining.tail
+
+        if head._2 == currentMagnification then rec(tail, currentLayers ++ head._1, currentMagnification, acc)
+        else rec(tail, head._1, head._2, acc :+ (currentLayers, currentMagnification))
+
+    if entries.length < 2 then entries
+    else
+      val head = entries.head
+      val tail = entries.tail
+
+      rec(tail, head._1, head._2, Batch.empty)
 
   def compactContentLayers(contentLayers: Batch[Layer.Content]): Batch[Layer.Content] =
     @tailrec

--- a/indigo-render-pipeline/src/indigo/render/pipeline/sceneprocessing/utils/CompactLayers.scala
+++ b/indigo-render-pipeline/src/indigo/render/pipeline/sceneprocessing/utils/CompactLayers.scala
@@ -29,15 +29,27 @@ object CompactLayers:
           else Batch((ls, cfg.giveMagnification))
       }
 
-    // Step 2: Squash the outer batch, where the magnification is the same.
+    // Step 2: Remove no-op content layers, i.e. layers with no scene nodes to
+    // render and no blending set. Node-less layers with explicit blending are
+    // kept because they can still affect the output, e.g. via a clear color or
+    // an ambient lighting blend. Removing no-ops early gives the later steps
+    // more merging opportunities.
     val step2 =
-      compactByMagnification(step1)
+      step1.flatMap { case (layers, magnification) =>
+        val filtered = layers.filter(l => l.nodes.nonEmpty || l.blending.nonEmpty)
+        if filtered.isEmpty then Batch.empty
+        else Batch(filtered -> magnification)
+      }
 
-    // Step 3: Compact Content layers within each sub-group.
+    // Step 3: Squash the outer batch, where the magnification is the same.
     val step3 =
-      step2.map { case (layers, mag) => (compactContentLayers(layers), mag) }
+      compactByMagnification(step2)
 
-    step3
+    // Step 4: Compact Content layers within each sub-group.
+    val step4 =
+      step3.map { case (layers, mag) => (compactContentLayers(layers), mag) }
+
+    step4
 
   def compactByMagnification(
       entries: Batch[(Batch[Layer.Content], Magnification)]

--- a/indigo-render-pipeline/test/src/indigo/render/pipeline/sceneprocessing/SceneProcessorTests.scala
+++ b/indigo-render-pipeline/test/src/indigo/render/pipeline/sceneprocessing/SceneProcessorTests.scala
@@ -6,6 +6,7 @@ import indigo.core.datatypes.Rectangle
 import indigo.core.datatypes.Size
 import indigo.core.datatypes.Vector2
 import indigo.core.events.GlobalEvent
+import indigo.core.render.Magnification
 import indigo.core.time.GameTime
 import indigo.core.utils.QuickCache
 import indigo.render.pipeline.assets.AssetMapping
@@ -14,6 +15,7 @@ import indigo.render.pipeline.assets.TextureRefAndOffset
 import indigo.render.pipeline.displayprocessing.DisplayObjectConversions
 import indigo.scenegraph.Graphic
 import indigo.scenegraph.Layer
+import indigo.scenegraph.LayerEntry
 import indigo.scenegraph.SceneUpdateFragment
 import indigo.scenegraph.materials.Material
 import indigo.scenegraph.registers.AnimationsRegister
@@ -67,12 +69,34 @@ class SceneProcessorTests extends munit.FunSuite {
     assertEquals(layer.bgColor, RGBA.Zero)
   }
 
-  test("makeDisplayLayers - two separate layers") {
+  test("makeDisplayLayers - two layer entries with the same properties compact into one") {
     val graphic1 = Graphic(Size(50), Material.Bitmap(AssetName("texture"))).withCrop(Rectangle(0, 0, 50, 50))
     val graphic2 = Graphic(Size(50), Material.Bitmap(AssetName("texture"))).withCrop(Rectangle(100, 100, 50, 50))
     val scene = SceneUpdateFragment(
       LayerKey("a") -> Layer(graphic1),
       LayerKey("b") -> Layer(graphic2)
+    )
+
+    val result = SceneProcessor.makeDisplayLayers(
+      scene,
+      Batch.empty[GlobalEvent],
+      (_: GlobalEvent) => (),
+      doc
+    )
+
+    val (layers, _) = result
+
+    assertEquals(layers.length, 1)
+    assertEquals(layers(0).entities.length, 2)
+  }
+
+  test("makeDisplayLayers - two layer entries with different magnifications remain separate") {
+    val graphic1 = Graphic(Size(50), Material.Bitmap(AssetName("texture"))).withCrop(Rectangle(0, 0, 50, 50))
+    val graphic2 = Graphic(Size(50), Material.Bitmap(AssetName("texture"))).withCrop(Rectangle(100, 100, 50, 50))
+    val scene = SceneUpdateFragment(
+      LayerKey("a") -> Layer(graphic1)
+    ).addLayer(
+      LayerEntry(LayerKey("b"), Layer(graphic2)).withMagnification(Magnification.x2)
     )
 
     val result = SceneProcessor.makeDisplayLayers(

--- a/indigo-render-pipeline/test/src/indigo/render/pipeline/sceneprocessing/utils/CompactLayersTests.scala
+++ b/indigo-render-pipeline/test/src/indigo/render/pipeline/sceneprocessing/utils/CompactLayersTests.scala
@@ -5,6 +5,7 @@ import indigo.core.datatypes.LayerKey
 import indigo.core.datatypes.Point
 import indigo.core.datatypes.Rectangle
 import indigo.core.render.Magnification
+import indigo.scenegraph.Blending
 import indigo.scenegraph.Camera
 import indigo.scenegraph.Layer
 import indigo.scenegraph.LayerEntry
@@ -73,6 +74,46 @@ class CompactLayersTests extends munit.FunSuite:
     assertEquals(clue(actual), clue(expected))
   }
 
+  test("no-op empty layers are removed, allowing groups to merge across them") {
+    val entries: Batch[LayerEntry] =
+      Batch(
+        LayerEntry(LayerKey("a"), Layer.Content(shape)).withMagnification(Magnification.x2),
+        LayerEntry(LayerKey("b"), Layer.empty),
+        LayerEntry(LayerKey("c"), Layer.Content(shape)).withMagnification(Magnification.x2)
+      )
+
+    val actual =
+      CompactLayers.compactLayers(entries)
+
+    val expected =
+      Batch(
+        (Batch(Layer.Content(shape, shape)), Magnification.x2)
+      )
+
+    assertEquals(clue(actual), clue(expected))
+  }
+
+  test("empty layers with blending are kept, they can still affect the output") {
+    val lighting: Layer.Content =
+      Layer.Content.empty.withBlending(Blending.Lighting(RGBA.Black))
+
+    val entries: Batch[LayerEntry] =
+      Batch(
+        LayerEntry(LayerKey("game"), Layer.Content(shape)),
+        LayerEntry(LayerKey("lighting"), lighting)
+      )
+
+    val actual =
+      CompactLayers.compactLayers(entries)
+
+    val expected =
+      Batch(
+        (Batch(Layer.Content(shape), lighting), Magnification.x1)
+      )
+
+    assertEquals(clue(actual), clue(expected))
+  }
+
   test("compactByMagnification") {
 
     // This would be the results of 'unstacking'
@@ -133,6 +174,7 @@ class CompactLayersTests extends munit.FunSuite:
 
   lazy val uncompacted: Batch[LayerEntry] =
     Batch(
+      LayerEntry(LayerKey("z"), Layer.Content(shape)).withMagnification(Magnification.x3),
       LayerEntry(LayerKey("a"), Layer.empty).withMagnification(Magnification.x2),
       LayerEntry(LayerKey("b"), Layer.empty),
       LayerEntry(
@@ -158,7 +200,7 @@ class CompactLayersTests extends munit.FunSuite:
 
   lazy val compacted: Batch[(Batch[Layer.Content], Magnification)] =
     Batch(
-      (Batch(Layer.Content.empty), Magnification.x2),
+      (Batch(Layer.Content(shape)), Magnification.x3),
       (
         Batch(
           Layer.Content(shape, shape),

--- a/indigo-render-pipeline/test/src/indigo/render/pipeline/sceneprocessing/utils/CompactLayersTests.scala
+++ b/indigo-render-pipeline/test/src/indigo/render/pipeline/sceneprocessing/utils/CompactLayersTests.scala
@@ -27,6 +27,107 @@ class CompactLayersTests extends munit.FunSuite:
     assertEquals(clue(actual), clue(expected))
   }
 
+  test("magnification is applied once per LayerEntry, not compounded by nesting") {
+    val entry: LayerEntry =
+      LayerEntry(
+        LayerKey("deeply-nested"),
+        Layer.Stack(
+          Layer.Content(shape),
+          Layer.Stack(
+            Layer.Content(shape),
+            Layer.Stack(
+              Layer.Content(shape)
+            )
+          )
+        )
+      ).withMagnification(Magnification.x2)
+
+    val actual =
+      CompactLayers.compactLayers(Batch(entry))
+
+    // One group, carrying the entry's single x2 magnification - not x2 * x2 * x2.
+    assertEquals(actual.length, 1)
+
+    val (contents, magnification) = actual.head
+    assertEquals(magnification, Magnification.x2)
+    // All nested content layers share the same camera/blend/lights, so they compact to one.
+    assertEquals(contents, Batch(Layer.Content(shape, shape, shape)))
+  }
+
+  test("hidden entries are removed, allowing their neighbours to merge") {
+    val entries: Batch[LayerEntry] =
+      Batch(
+        LayerEntry(LayerKey("a"), Layer.Content(shape)),
+        LayerEntry(LayerKey("b"), Layer.Content(shape)).hide,
+        LayerEntry(LayerKey("c"), Layer.Content(shape))
+      )
+
+    val actual =
+      CompactLayers.compactLayers(entries)
+
+    val expected =
+      Batch(
+        (Batch(Layer.Content(shape, shape)), Magnification.x1)
+      )
+
+    assertEquals(clue(actual), clue(expected))
+  }
+
+  test("compactByMagnification") {
+
+    // This would be the results of 'unstacking'
+    val unstacked =
+      Batch(
+        (Batch(Layer.Content.empty), Magnification.x2),
+        (Batch(Layer.Content.empty), Magnification.x1),
+        (Batch(Layer.Content.empty), Magnification.x1),
+        (Batch(Layer.Content.empty), Magnification.x1),
+        (Batch(Layer.Content(shape, shape)), Magnification.x1),
+        (
+          Batch(
+            Layer.Content(shape).withCamera(Camera.Fixed(Point.zero)),
+            Layer.Content(shape, shape).withCamera(Camera.Fixed(Point(10))),
+            Layer.Content(shape)
+          ),
+          Magnification.x3
+        ),
+        (Batch(Layer.Content.empty), Magnification.x3),
+        (Batch(Layer.Content.empty), Magnification.x2),
+        (Batch(Layer.Content.empty), Magnification.x2),
+        (Batch(Layer.Content(shape)), Magnification.x2)
+      )
+
+    // This process does not remove layers, just flattens the groups down when they share the same magnification.
+    val actual =
+      CompactLayers.compactByMagnification(unstacked)
+
+    val expected =
+      Batch(
+        (Batch(Layer.Content.empty), Magnification.x2),
+        (
+          Batch(
+            Layer.Content.empty,
+            Layer.Content.empty,
+            Layer.Content.empty,
+            Layer.Content(shape, shape)
+          ),
+          Magnification.x1
+        ),
+        (
+          Batch(
+            Layer.Content(shape).withCamera(Camera.Fixed(Point.zero)),
+            Layer.Content(shape, shape).withCamera(Camera.Fixed(Point(10))),
+            Layer.Content(shape),
+            Layer.Content.empty
+          ),
+          Magnification.x3
+        ),
+        (Batch(Layer.Content.empty, Layer.Content.empty, Layer.Content(shape)), Magnification.x2)
+      )
+
+    assertEquals(actual, expected)
+  }
+
   lazy val shape: Shape.Box =
     Shape.Box(Rectangle(0, 0, 100, 100), Fill.Color(RGBA.Red))
 
@@ -58,46 +159,13 @@ class CompactLayersTests extends munit.FunSuite:
   lazy val compacted: Batch[(Batch[Layer.Content], Magnification)] =
     Batch(
       (Batch(Layer.Content.empty), Magnification.x2),
-      (Batch(Layer.Content.empty), Magnification.default),
       (
         Batch(
-          Layer.Content(shape, shape)
-        ),
-        Magnification.default
-      ),
-      (
-        Batch(
+          Layer.Content(shape, shape),
           Layer.Content(shape).withCamera(Camera.Fixed(Point.zero)),
           Layer.Content(shape, shape).withCamera(Camera.Fixed(Point(10))),
           Layer.Content(shape)
         ),
-        Magnification.default
+        Magnification.x1
       )
     )
-
-  test("magnification is applied once per LayerEntry, not compounded by nesting") {
-    val entry: LayerEntry =
-      LayerEntry(
-        LayerKey("deeply-nested"),
-        Layer.Stack(
-          Layer.Content(shape),
-          Layer.Stack(
-            Layer.Content(shape),
-            Layer.Stack(
-              Layer.Content(shape)
-            )
-          )
-        )
-      ).withMagnification(Magnification.x2)
-
-    val actual =
-      CompactLayers.compactLayers(Batch(entry))
-
-    // One group, carrying the entry's single x2 magnification - not x2 * x2 * x2.
-    assertEquals(actual.length, 1)
-
-    val (contents, magnification) = actual.head
-    assertEquals(magnification, Magnification.x2)
-    // All nested content layers share the same camera/blend/lights, so they compact to one.
-    assertEquals(contents, Batch(Layer.Content(shape, shape, shape)))
-  }

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ConfettiScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ConfettiScene.scala
@@ -87,7 +87,7 @@ object ConfettiScene extends Scene[SandboxGameModel]:
           )
         )
       ).addCloneBlanks(cloneBlanks)
-        .withMagnification(Magnification(2))
+        .withMagnification(Magnification(1))
     )
 
 final case class ConfettiModel(color: Int, particles: Batch[Batch[Particle]]):

--- a/indigo-scenegraph/src/indigo/scenegraph/Layer.scala
+++ b/indigo-scenegraph/src/indigo/scenegraph/Layer.scala
@@ -48,8 +48,8 @@ enum Layer derives CanEqual:
       nodes: Batch[SceneNode],
       cloneBlanks: Batch[CloneBlank],
       lights: Batch[Light],
-      blending: Option[Blending], // TODO: Can we make this non-optional?
-      camera: Option[Camera]      // TODO: Can we make this non-optional?
+      blending: Option[Blending],
+      camera: Option[Camera]
   )
 
   def toBatch: Batch[Layer.Content] =


### PR DESCRIPTION
The aim here is to reduce the number of layer composites we do, by more efficiently collapsing neighbouring layers and groups of layers.

Relates to:

- #234 
- #233 