### PR TITLE
docs: document macOS Electron Keychain prompt workaround (Fixes #149)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -273,6 +273,7 @@ For game development with Indigo, use these entry points:
 ## Additional Tools and Dependencies
 
 **Optional JS Tools**: Node.js, Yarn, Electron (for demo/sandbox projects)  
+> *Note for macOS Electron Dev*: If Electron prompts for Keychain access on startup (see Electron #43233), hit `Esc` or use `--disable-encryption` / `--password-store=basic`.  
 **Nix Support**: `flake.nix` provides a reproducible dev environment with JDK 17, Mill, Node.js, Yarn, Electron
 
 ## Quick Reference

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ This is a predominately [Mill](https://mill-build.org/) based monorepo.
 
 Aside from your usual Scala set up, the tools you may need are JS tools: Node.js, Yarn, and potentially Electron. There is a Nix flake provided, if you like that sort of thing.
 
+> **Note (macOS & Electron Keychain Prompt)**: When launching Electron during local development on macOS, a system Keychain access dialog may pop up (see [Electron issue #43233](https://github.com/electron/electron/issues/43233)). This is a known Electron dev-mode behavior. You can safely dismiss it by pressing `Esc`, or pass `--disable-encryption` / `--password-store=basic` to your Electron launch flags.
+
 You are highly encouraged to look at the very simple `build.sh` script, which you can run with `bash build.sh`.
 
 ***The important thing to note*** is that running Scala.js linking on all of the modules at once is a _very_ heavy operation that may grind your build to a halt.


### PR DESCRIPTION
Fixes #149.

### 📝 Description
This PR documents the known workaround for the macOS Electron Keychain access prompt popup during local development (referencing Electron issue [#43233](https://github.com/electron/electron/issues/43233)).

### 🛡️ Audit & Changes
1. **Updated `README.md`**: Added a note in the **Developers & Contributors** section detailing the `Esc` key workaround and `--disable-encryption` / `--password-store=basic` flags.
2. **Updated `.github/copilot-instructions.md`**: Added quick reference note under Additional Tools for Electron dev setup.

- Zero runtime breaking changes.
- Tested and verified markdown formatting.

Closes #149
