### PR TITLE
FIXED #264: Actors use custom view types

### DIFF
--- a/indigo-extras/src/indigoextras/actors/Actor.scala
+++ b/indigo-extras/src/indigoextras/actors/Actor.scala
@@ -2,16 +2,15 @@ package indigoextras.actors
 
 import indigo.core.Outcome
 import indigo.core.events.GlobalEvent
-import indigo.scenegraph.SceneNode
-import indigoengine.shared.collections.Batch
 
 /** An Actor is a standalone entity that can update and present itself, and communicates with the world by reading
   * shared immutable data (`ReferenceData`) from the game model, and by receiving and emitting events.
   *
   * The Actor typeclass allows you to define an Actor for any type, so long as you can meaningfully provide an update
-  * and a present function for it.
+  * and a present function for it. The present function can produce any view data that can be used by the pool to
+  * represent the actor, anything from a batch of scene nodes to clone data to a custom type you interpret later.
   */
-trait Actor[ReferenceData, ActorType]:
+trait Actor[ReferenceData, ActorType, ActorView]:
 
   /** Update this actor.
     */
@@ -19,4 +18,4 @@ trait Actor[ReferenceData, ActorType]:
 
   /** Draw the actor.
     */
-  def present(context: ActorContext[ReferenceData, ActorType], actor: ActorType): Outcome[Batch[SceneNode]]
+  def present(context: ActorContext[ReferenceData, ActorType], actor: ActorType): Outcome[ActorView]

--- a/indigo-extras/src/indigoextras/actors/ActorInstance.scala
+++ b/indigo-extras/src/indigoextras/actors/ActorInstance.scala
@@ -1,3 +1,6 @@
 package indigoextras.actors
 
-final case class ActorInstance[ReferenceData, ActorType](instance: ActorType, actor: Actor[ReferenceData, ActorType])
+final case class ActorInstance[ReferenceData, ActorType, ActorView](
+    instance: ActorType,
+    actor: Actor[ReferenceData, ActorType, ActorView]
+)

--- a/indigo-extras/src/indigoextras/actors/ActorPool.scala
+++ b/indigo-extras/src/indigoextras/actors/ActorPool.scala
@@ -4,24 +4,27 @@ import indigo.SubSystemContext
 import indigo.core.Outcome
 import indigo.core.events.FrameTick
 import indigo.core.events.GlobalEvent
-import indigo.scenegraph.SceneNode
+import indigo.scenegraph.SceneUpdateFragment
 import indigo.scenes.SceneContext
 import indigo.shared.Context
 import indigoengine.shared.collections.Batch
 
-final case class ActorPool[ReferenceData, ActorType](
-    actors: Batch[ActorInstance[ReferenceData, ActorType]]
-)(using Ordering[ActorType]):
+/** Holds, manages and presents a pool of Actors.
+  */
+final case class ActorPool[ReferenceData, ActorType, ActorView](
+    actors: Batch[ActorInstance[ReferenceData, ActorType, ActorView]],
+    toSceneUpdateFragment: Batch[ActorView] => SceneUpdateFragment
+)(using Ordering[ActorType])(using actor: Actor[ReferenceData, ActorType, ActorView]):
 
-  private val orderingInstance: Ordering[ActorInstance[ReferenceData, ActorType]] =
+  private val orderingInstance: Ordering[ActorInstance[ReferenceData, ActorType, ActorView]] =
     Ordering.by(a => a.instance)
 
   /** Update the actor pool, passing in the model and a standard context. */
   def update(
       context: Context,
       model: ReferenceData
-  ): GlobalEvent => Outcome[ActorPool[ReferenceData, ActorType]] =
-    val nextPool: GlobalEvent => Outcome[Batch[ActorInstance[ReferenceData, ActorType]]] =
+  ): GlobalEvent => Outcome[ActorPool[ReferenceData, ActorType, ActorView]] =
+    val nextPool: GlobalEvent => Outcome[Batch[ActorInstance[ReferenceData, ActorType, ActorView]]] =
       case FrameTick =>
         actors
           .map { ai =>
@@ -33,7 +36,7 @@ final case class ActorPool[ReferenceData, ActorType](
           }
           .sequence
           .map { actorInstances =>
-            actorInstances.sorted[ActorInstance[ReferenceData, ActorType]](using orderingInstance)
+            actorInstances.sorted[ActorInstance[ReferenceData, ActorType, ActorView]](using orderingInstance)
           }
 
       case e =>
@@ -51,20 +54,20 @@ final case class ActorPool[ReferenceData, ActorType](
   def update(
       context: SceneContext,
       model: ReferenceData
-  ): GlobalEvent => Outcome[ActorPool[ReferenceData, ActorType]] =
+  ): GlobalEvent => Outcome[ActorPool[ReferenceData, ActorType, ActorView]] =
     update(context.toContext, model)
 
   /** Update the actor pool, passing in the model and a subsystem context. */
   def update(
       context: SubSystemContext[?],
       model: ReferenceData
-  ): GlobalEvent => Outcome[ActorPool[ReferenceData, ActorType]] =
+  ): GlobalEvent => Outcome[ActorPool[ReferenceData, ActorType, ActorView]] =
     update(context.toContext, model)
 
   def present(
       context: Context,
       model: ReferenceData
-  ): Outcome[Batch[SceneNode]] =
+  ): Outcome[SceneUpdateFragment] =
     actors
       .map { ai =>
         val ctx = ActorContext(find, model, context)
@@ -72,18 +75,18 @@ final case class ActorPool[ReferenceData, ActorType](
         ai.actor.present(ctx, ai.instance)
       }
       .sequence
-      .map(_.flatten)
+      .map(toSceneUpdateFragment)
 
   def present(
       context: SceneContext,
       model: ReferenceData
-  ): Outcome[Batch[SceneNode]] =
+  ): Outcome[SceneUpdateFragment] =
     present(context.toContext, model)
 
   def present(
       context: SubSystemContext[?],
       model: ReferenceData
-  ): Outcome[Batch[SceneNode]] =
+  ): Outcome[SceneUpdateFragment] =
     present(context.toContext, model)
 
   /** Finds the first actor in the pool that matches the predicate test. */
@@ -99,19 +102,19 @@ final case class ActorPool[ReferenceData, ActorType](
     actors.filterNot(ai => p(ai.instance)).map(_.instance)
 
   /** Spawns a batch of new actor in the pool. */
-  def spawn[B <: ActorType](
-      newActors: Batch[B]
-  )(using actor: Actor[ReferenceData, B]): ActorPool[ReferenceData, ActorType] =
+  def spawn(
+      newActors: Batch[ActorType]
+  ): ActorPool[ReferenceData, ActorType, ActorView] =
     this.copy(
-      actors = actors ++ newActors.map(a => ActorInstance(a, actor.asInstanceOf[Actor[ReferenceData, ActorType]]))
+      actors = actors ++ newActors.map(a => ActorInstance(a, actor))
     )
 
   /** Spawns new actors in the pool. */
-  def spawn[B <: ActorType](newActors: B*)(using actor: Actor[ReferenceData, B]): ActorPool[ReferenceData, ActorType] =
+  def spawn(newActors: ActorType*): ActorPool[ReferenceData, ActorType, ActorView] =
     spawn(Batch.fromSeq(newActors))
 
   /** Kills any actors in the pool that match the predicate test. */
-  def kill(p: ActorType => Boolean): ActorPool[ReferenceData, ActorType] =
+  def kill(p: ActorType => Boolean): ActorPool[ReferenceData, ActorType, ActorView] =
     this.copy(
       actors = actors.filterNot(ai => p(ai.instance))
     )
@@ -121,8 +124,8 @@ final case class ActorPool[ReferenceData, ActorType](
 
 object ActorPool:
 
-  def empty[ReferenceData, ActorType](using Ordering[ActorType]): ActorPool[ReferenceData, ActorType] =
-    apply()
-
-  def apply[ReferenceData, ActorType]()(using Ordering[ActorType]): ActorPool[ReferenceData, ActorType] =
-    ActorPool(Batch.empty)
+  def apply[ReferenceData, ActorType, ActorView](toSceneUpdateFragment: Batch[ActorView] => SceneUpdateFragment)(using
+      Ordering[ActorType],
+      Actor[ReferenceData, ActorType, ActorView]
+  ): ActorPool[ReferenceData, ActorType, ActorView] =
+    ActorPool(Batch.empty, toSceneUpdateFragment)

--- a/indigo-extras/test/src/indigoextras/actors/ActorPoolTests.scala
+++ b/indigo-extras/test/src/indigoextras/actors/ActorPoolTests.scala
@@ -5,13 +5,15 @@ import indigo.*
 class ActorPoolTests extends munit.FunSuite {
 
   test("ActorPool should be created with an empty list of actors") {
-    val actorPool = ActorPool.empty[Unit, String]
+    val actorPool =
+      ActorPool[Unit, String, SceneNode](_ => SceneUpdateFragment.empty)
 
     assertEquals(actorPool.toBatch.length, 0)
   }
 
   test("spawn") {
-    val actorPool = ActorPool.empty[Unit, String]
+    val actorPool =
+      ActorPool[Unit, String, SceneNode](_ => SceneUpdateFragment.empty)
     val newActors = Batch("Actor1", "Actor2", "Actor3")
 
     val updatedPool = actorPool.spawn(newActors)
@@ -20,14 +22,18 @@ class ActorPoolTests extends munit.FunSuite {
   }
 
   test("find") {
-    val actorPool = ActorPool.empty[Unit, String].spawn("Actor1", "Actor2", "Actor3")
+    val actorPool =
+      ActorPool[Unit, String, SceneNode](_ => SceneUpdateFragment.empty)
+        .spawn("Actor1", "Actor2", "Actor3")
 
     val foundActor = actorPool.find(_ == "Actor2")
 
     assertEquals(foundActor, Some("Actor2"))
   }
+
   test("filter") {
-    val actorPool = ActorPool.empty[Unit, String].spawn("Actor1", "Actor2", "Actor3")
+    val actorPool =
+      ActorPool[Unit, String, SceneNode](_ => SceneUpdateFragment.empty).spawn("Actor1", "Actor2", "Actor3")
 
     val filteredActors = actorPool.filter(_ == "Actor2")
 
@@ -35,7 +41,8 @@ class ActorPoolTests extends munit.FunSuite {
   }
 
   test("filterNot") {
-    val actorPool = ActorPool.empty[Unit, String].spawn("Actor1", "Actor2", "Actor3")
+    val actorPool =
+      ActorPool[Unit, String, SceneNode](_ => SceneUpdateFragment.empty).spawn("Actor1", "Actor2", "Actor3")
 
     val filteredActors = actorPool.filterNot(_ == "Actor2")
 
@@ -43,7 +50,8 @@ class ActorPoolTests extends munit.FunSuite {
   }
 
   test("kill") {
-    val actorPool = ActorPool.empty[Unit, String].spawn("Actor1", "Actor2", "Actor3")
+    val actorPool =
+      ActorPool[Unit, String, SceneNode](_ => SceneUpdateFragment.empty).spawn("Actor1", "Actor2", "Actor3")
 
     val updatedPool = actorPool.kill(_ == "Actor2")
 
@@ -51,7 +59,8 @@ class ActorPoolTests extends munit.FunSuite {
   }
 
   test("update") {
-    val actorPool = ActorPool.empty[Unit, String].spawn("Actor1", "Actor2", "Actor3")
+    val actorPool =
+      ActorPool[Unit, String, SceneNode](_ => SceneUpdateFragment.empty).spawn("Actor1", "Actor2", "Actor3")
 
     val ctx: Context =
       Context.initial
@@ -62,20 +71,30 @@ class ActorPoolTests extends munit.FunSuite {
   }
 
   test("present") {
-    val actorPool = ActorPool.empty[Unit, String].spawn("Actor1", "Actor2", "Actor3")
+    val actorPool =
+      ActorPool[Unit, String, SceneNode](nodes =>
+        SceneUpdateFragment(
+          LayerKey("test") -> Layer.Content(nodes)
+        )
+      ).spawn("Actor1", "Actor2", "Actor3")
 
     val ctx: Context =
       Context.initial
 
     val presented = actorPool.present(ctx, ())
 
-    assertEquals(presented.unsafeGet.length, 3)
+    presented.unsafeGet.layers.head.layer match
+      case Layer.Stack(_) =>
+        fail("Uh oh.")
+
+      case Layer.Content(nodes, _, _, _, _) =>
+        assertEquals(nodes.length, 3)
   }
 
-  given Actor[Unit, String] with
+  given Actor[Unit, String, SceneNode] with
     def update(context: ActorContext[Unit, String], actor: String): GlobalEvent => Outcome[String] =
       _ => Outcome(actor + "!")
 
-    def present(context: ActorContext[Unit, String], actor: String): Outcome[Batch[SceneNode]] =
-      Outcome(Batch(Text(actor, FontKey("test"), Material.Bitmap(AssetName("test")))))
+    def present(context: ActorContext[Unit, String], actor: String): Outcome[SceneNode] =
+      Outcome(Text(actor, FontKey("test"), Material.Bitmap(AssetName("test"))))
 }

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ActorPoolPhysicsScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ActorPoolPhysicsScene.scala
@@ -34,7 +34,7 @@ object ActorPoolPhysicsScene extends Scene[SandboxGameModel]:
   ): GlobalEvent => Outcome[ActorPhysicsSceneModel] =
     case FrameTick if !model.spawned =>
       val zombies: Batch[(ZombieActor, Collider[ZombieSimTag])] =
-        (0 to 30).toBatch.map { i =>
+        (0 to 100).toBatch.map { i =>
           val dice = Dice.fromSeed(i.toLong)
 
           val x =
@@ -133,25 +133,35 @@ object ActorPoolPhysicsScene extends Scene[SandboxGameModel]:
         Constants.LayerKeys.background ->
           Layer.Content(
             Shape.Circle(Circle(model.target, 16), Fill.Color(RGBA.Red), Stroke(2, RGBA.White))
-          ),
-        Constants.LayerKeys.game -> Layer.Content(
-          zombies
-        )
-      )
+          )
+      ) |+| zombies
     }
 
 final case class ActorPhysicsSceneModel(
     spawned: Boolean,
     target: Point,
-    actorPool: ActorPool[Map[Int, Point], ZombieActor],
+    actorPool: ActorPool[Map[Int, Point], ZombieActor, CloneBatchData],
     world: World[ZombieSimTag]
 )
 object ActorPhysicsSceneModel:
+
+  private val blank =
+    CloneBlank(
+      CloneId("zombie-clone"),
+      Shape.Circle(Circle(Point.zero, 5), Fill.Color(RGBA.SlateGray), Stroke(1, RGBA.White))
+    )
+
   val initial: ActorPhysicsSceneModel =
     ActorPhysicsSceneModel(
       false,
       Point.zero,
-      ActorPool.empty,
+      ActorPool(cloneData =>
+        SceneUpdateFragment(
+          Constants.LayerKeys.game -> Layer.Content(
+            CloneBatch(blank.id, cloneData)
+          )
+        ).addCloneBlanks(blank)
+      ),
       World.empty.withResistance(Resistance(0.25))
     )
 
@@ -166,7 +176,7 @@ object ZombieActor:
   given Ordering[ZombieActor] =
     Ordering.by(_.depth)
 
-  given Actor[Map[Int, Point], ZombieActor] with
+  given Actor[Map[Int, Point], ZombieActor, CloneBatchData] with
 
     def update(
         context: ActorContext[Map[Int, Point], ZombieActor],
@@ -185,17 +195,9 @@ object ZombieActor:
       case _ =>
         Outcome(actor)
 
-    def present(context: ActorContext[Map[Int, Point], ZombieActor], actor: ZombieActor): Outcome[Batch[SceneNode]] =
-      val color =
-        actor.index % 3 match
-          case 0 => RGBA.Cyan
-          case 1 => RGBA.Yellow
-          case _ => RGBA.SlateGray
-
+    def present(context: ActorContext[Map[Int, Point], ZombieActor], actor: ZombieActor): Outcome[CloneBatchData] =
       Outcome(
-        Batch(
-          Shape.Circle(Circle(actor.position, 5), Fill.Color(color), Stroke(1, RGBA.White))
-        )
+        CloneBatchData(actor.position.x, actor.position.y)
       )
 
 enum ZombieSimTag derives CanEqual:

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ActorPoolScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ActorPoolScene.scala
@@ -98,20 +98,27 @@ object ActorPoolScene extends Scene[SandboxGameModel]:
         Constants.LayerKeys.background ->
           Layer.Content(
             Shape.Circle(Circle(model.target, 8), Fill.Color(RGBA.Cyan))
-          ),
-        Constants.LayerKeys.game -> Layer.Content(
-          followers
-        )
-      )
+          )
+      ) |+| followers
     }
 
-final case class ActorSceneModel(spawned: Boolean, target: Point, actorSystem: ActorPool[Point, FollowingActor])
+final case class ActorSceneModel(
+    spawned: Boolean,
+    target: Point,
+    actorSystem: ActorPool[Point, FollowingActor, SceneNode]
+)
 object ActorSceneModel:
   val initial: ActorSceneModel =
     ActorSceneModel(
       false,
       Point.zero,
-      ActorPool.empty
+      ActorPool(nodes =>
+        SceneUpdateFragment(
+          Constants.LayerKeys.game -> Layer.Content(
+            nodes
+          )
+        )
+      )
     )
 
 enum FollowingActor(
@@ -148,7 +155,7 @@ object FollowingActor:
   given Ordering[FollowingActor] =
     Ordering.by(_.depthIndex)
 
-  given Actor[Point, FollowingActor] with
+  given Actor[Point, FollowingActor, SceneNode] with
 
     def update(
         context: ActorContext[Point, FollowingActor],
@@ -173,9 +180,7 @@ object FollowingActor:
     def present(
         context: ActorContext[Point, FollowingActor],
         actor: FollowingActor
-    ): Outcome[Batch[SceneNode]] =
+    ): Outcome[SceneNode] =
       Outcome(
-        Batch(
-          Shape.Circle(Circle(actor.location.toPoint, actor.radius), Fill.Color(actor.colour), Stroke(2, RGBA.Black))
-        )
+        Shape.Circle(Circle(actor.location.toPoint, actor.radius), Fill.Color(actor.colour), Stroke(2, RGBA.Black))
       )


### PR DESCRIPTION
Relates to: https://github.com/PurpleKingdomGames/indigoengine/issues/264

This PR gives Actors more powerful presentation options. The actors themselves now define a custom view type, and the ActorPool now requires a function from a batch of that view type to a SceneUpdateFragment. This allows everything from trivial views with normal scene nodes like graphics, to clones / clone tiles, and even (in theory) custom data -> single blank entity with a custom shader that renders everything.

I did not, ultimately, decide to apply the same change to performers. Performers are a bit different to Actors - more opinionated by design - and a) I was reluctant to add more complexity to them, and b) I felt like un-opinionated Actors could support these arguably even looser definitions better than performers could.