### PR TITLE
FIXED #252: Drawing with Quads

### DIFF
--- a/indigo-core/src/indigo/core/datatypes/Size.scala
+++ b/indigo-core/src/indigo/core/datatypes/Size.scala
@@ -24,12 +24,12 @@ final case class Size(width: Int, height: Int) derives CanEqual:
   def withHeight(newY: Int): Size = this.copy(height = newY)
 
   def shortestSide: Int =
-    if width < height then width else height
+    Math.min(Math.abs(width), Math.abs(height))
   def longestSide: Int =
-    if width > height then width else height
+    Math.max(Math.abs(width), Math.abs(height))
 
   def halfSize: Size =
-    this / 2
+    (this / 2).abs
 
   def abs: Size =
     Size(Math.abs(width), Math.abs(height))

--- a/indigo-core/src/indigo/core/datatypes/Size.scala
+++ b/indigo-core/src/indigo/core/datatypes/Size.scala
@@ -23,6 +23,14 @@ final case class Size(width: Int, height: Int) derives CanEqual:
   def withWidth(newX: Int): Size  = this.copy(width = newX)
   def withHeight(newY: Int): Size = this.copy(height = newY)
 
+  def shortestSide: Int =
+    if width < height then width else height
+  def longestSide: Int =
+    if width > height then width else height
+
+  def halfSize: Size =
+    this / 2
+
   def abs: Size =
     Size(Math.abs(width), Math.abs(height))
 

--- a/indigo-core/test/src/indigo/core/datatypes/SizeTests.scala
+++ b/indigo-core/test/src/indigo/core/datatypes/SizeTests.scala
@@ -27,4 +27,18 @@ class SizeTests extends munit.FunSuite {
     assertEquals(Size(11, 12).max(12), Size(12, 12))
   }
 
+  test("short side") {
+    assertEquals(Size(5, 2).shortestSide, 2)
+    assertEquals(Size(2, 5).shortestSide, 2)
+  }
+
+  test("long side") {
+    assertEquals(Size(5, 2).longestSide, 5)
+    assertEquals(Size(2, 5).longestSide, 5)
+  }
+
+  test("half size") {
+    assertEquals(Size(5, 2).halfSize, Size(2, 1))
+  }
+
 }

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/SandboxGame.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/SandboxGame.scala
@@ -13,7 +13,7 @@ final class SandboxGame extends Game[SandboxBootData, SandboxStartupData, Sandbo
   val gameId: GameId = GameId("sandbox")
 
   def initialScene(bootData: SandboxBootData): Option[SceneName] =
-    Some(LineReflectionScene.name)
+    Some(QuadScene.name)
 
   def scenes(bootData: SandboxBootData): NonEmptyBatch[Scene[SandboxGameModel]] =
     ScenesList.scenes

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/QuadScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/QuadScene.scala
@@ -33,7 +33,7 @@ object QuadScene extends Scene[SandboxGameModel]:
   ): Outcome[SceneUpdateFragment] = {
 
     val squareSize: Size =
-      val signal = Signal.SmoothPulse.map(d => (100 * d).toInt).affectTime(0.25).at(context.frame.time.running)
+      val signal = Signal.SmoothPulse.map(d => (99 * d).toInt).affectTime(0.25).at(context.frame.time.running)
       Size(
         signal,
         99 - signal

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/QuadScene.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/QuadScene.scala
@@ -1,0 +1,83 @@
+package com.example.sandbox.scenes
+
+import com.example.sandbox.Constants
+import com.example.sandbox.SandboxGameModel
+import indigo.*
+import indigo.scenes.*
+
+object QuadScene extends Scene[SandboxGameModel]:
+
+  type SceneModel = SandboxGameModel
+
+  def eventFilters: EventFilters =
+    EventFilters.Restricted
+
+  def modelLens: Lens[SandboxGameModel, SandboxGameModel] =
+    Lens.keepOriginal
+
+  def name: SceneName =
+    SceneName("quads")
+
+  def subSystems: Set[SubSystem[SandboxGameModel]] =
+    Set()
+
+  def updateModel(
+      context: SceneContext,
+      model: SandboxGameModel
+  ): GlobalEvent => Outcome[SandboxGameModel] =
+    _ => Outcome(model)
+
+  def present(
+      context: SceneContext,
+      model: SandboxGameModel
+  ): Outcome[SceneUpdateFragment] = {
+
+    val squareSize: Size =
+      val signal = Signal.SmoothPulse.map(d => (100 * d).toInt).affectTime(0.25).at(context.frame.time.running)
+      Size(
+        signal,
+        99 - signal
+      )
+
+    val progressBar =
+      Group(
+        // Shadow
+        Quad(
+          Rectangle(Size(200, 12)),
+          Fill.Color(RGBA.Black.withAlpha(0.4))
+        ).moveBy(6, 6),
+        // Border
+        Quad(
+          Rectangle(Size(200, 12)),
+          Fill.Color(RGBA.Black)
+        ),
+        // Bar
+        Quad(
+          Rectangle(Size(200 - 34, 12 - 4)),
+          Fill.LinearGradient(Point(0, 0), RGBA.Red, Point(0, 8), RGBA.Yellow)
+        ).moveBy(2, 2)
+      ).moveBy(120, 120)
+
+    Outcome(
+      SceneUpdateFragment(
+        Constants.LayerKeys.game -> Layer
+          .Content(
+            Quad(
+              Rectangle(Point(60, 180), squareSize),
+              Fill.Color(RGBA.Red),
+              Corners(10, 5, 30, 15)
+            )
+              .withRef(squareSize.toPoint / 2),
+            Quad(Rectangle(10, 10, 100, 100), Fill.Color(RGBA.Green.withAlpha(0.5))),
+            Quad(Rectangle(120, 10, 100, 100), Fill.LinearGradient(Point.zero, RGBA.Magenta, Point(100), RGBA.Cyan))
+              .withCorners(Corners(10, 5, 30, 15)),
+            Quad(Rectangle(230, 10, 100, 100), Fill.RadialGradient(Point(40), RGBA.Cyan, Point(100), RGBA.DarkBlue))
+              .withCorners(Corners(10)),
+            Quad(Rectangle(330, 10, 100, 100), Fill.RadialGradient(Point(40), RGBA.White, Point(100), RGBA.Black))
+              .withCorners(Corners(1))
+              .rotateBy(Radians.fromDegrees(Degrees(45)))
+          )
+          .addNodes(progressBar)
+      ).withMagnification(Magnification.x2)
+    )
+  }

--- a/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ScenesList.scala
+++ b/indigo-sandboxes/sandbox/src-js/main/scala/com/example/sandbox/scenes/ScenesList.scala
@@ -45,5 +45,6 @@ object ScenesList:
       MultiPointScene,
       BgAudioScene,
       MagnificationScene,
-      LocaleScene
+      LocaleScene,
+      QuadScene
     )

--- a/indigo-scenegraph/src/indigo/scenegraph/Corners.scala
+++ b/indigo-scenegraph/src/indigo/scenegraph/Corners.scala
@@ -1,0 +1,49 @@
+package indigo.scenegraph
+
+import indigo.core.datatypes.Size
+
+/** Represents the radiuses of each corner of a Quad, so that they can be set independently.
+  */
+final case class Corners(topLeft: Int, topRight: Int, bottomRight: Int, bottomLeft: Int) derives CanEqual:
+
+  def withTopLeft(value: Int): Corners =
+    this.copy(topLeft = value)
+  def withTopRight(value: Int): Corners =
+    this.copy(topRight = value)
+  def withBottomRight(value: Int): Corners =
+    this.copy(bottomRight = value)
+  def withBottomLeft(value: Int): Corners =
+    this.copy(bottomLeft = value)
+
+  private def clampCorner(max: Int, corner: Int): Int =
+    Math.min(max, Math.max(0, corner))
+
+  def clampTo(size: Size): Corners =
+    val maxCornerSize = size.halfSize.shortestSide
+
+    Corners(
+      clampCorner(maxCornerSize, topLeft),
+      clampCorner(maxCornerSize, topRight),
+      clampCorner(maxCornerSize, bottomRight),
+      clampCorner(maxCornerSize, bottomLeft)
+    )
+
+object Corners:
+
+  def zero: Corners =
+    Corners(0)
+
+  def apply(all: Int): Corners =
+    Corners(all, all, all, all)
+
+  def topLeft(radius: Int): Corners =
+    Corners(radius, 0, 0, 0)
+
+  def topRight(radius: Int): Corners =
+    Corners(0, radius, 0, 0)
+
+  def bottomRight(radius: Int): Corners =
+    Corners(0, 0, radius, 0)
+
+  def bottomLeft(radius: Int): Corners =
+    Corners(0, 0, 0, radius)

--- a/indigo-scenegraph/src/indigo/scenegraph/Corners.scala
+++ b/indigo-scenegraph/src/indigo/scenegraph/Corners.scala
@@ -2,7 +2,7 @@ package indigo.scenegraph
 
 import indigo.core.datatypes.Size
 
-/** Represents the radiuses of each corner of a Quad, so that they can be set independently.
+/** Represents the radii of each corner of a Quad, so that they can be set independently.
   */
 final case class Corners(topLeft: Int, topRight: Int, bottomRight: Int, bottomLeft: Int) derives CanEqual:
 

--- a/indigo-scenegraph/src/indigo/scenegraph/Quad.scala
+++ b/indigo-scenegraph/src/indigo/scenegraph/Quad.scala
@@ -20,11 +20,11 @@ import indigoengine.shared.datatypes.Radians
 
 /** `Quad`s are used when you want to draw a pixel accurate box, with or without individual rounded corners. Unlike
   * `Shape.Box`, `Quad` does NOT support a `Stroke` (..though you can simulate it with another `Quad`), but it is pixel
-  * accurate* (as long as it is not rotated), allows you to define individual corner radii, and use either solid colors
-  * or gradient fills. An expected use-case would be drawing progress bars.
+  * accurate[^1] (as long as it is not rotated), allows you to define individual corner radii, and use either solid
+  * colors or gradient fills. An expected use-case would be drawing progress bars.
   *
-  * (*`Shape.Box` can suffer from floating point errors due to the SDF based drawing method common to all `Shape`
-  * types.)
+  * [^1]: `Shape.Box` can suffer from floating point errors due to the SDF based drawing method common to all `Shape`
+  * types.
   */
 final case class Quad(
     dimensions: Rectangle,

--- a/indigo-scenegraph/src/indigo/scenegraph/Quad.scala
+++ b/indigo-scenegraph/src/indigo/scenegraph/Quad.scala
@@ -1,0 +1,199 @@
+package indigo.scenegraph
+
+import indigo.core.datatypes.Fill
+import indigo.core.datatypes.Flip
+import indigo.core.datatypes.Point
+import indigo.core.datatypes.Rectangle
+import indigo.core.datatypes.Size
+import indigo.core.datatypes.Vector2
+import indigo.core.events.GlobalEvent
+import indigo.scenegraph.materials.LightingModel
+import indigo.shaders.ShaderData
+import indigo.shaders.ShaderPrimitive
+import indigo.shaders.StandardShaders
+import indigo.shaders.Uniform
+import indigo.shaders.UniformBlock
+import indigo.shaders.UniformBlockName
+import indigo.shaders.UniformDataHelpers
+import indigoengine.shared.collections.Batch
+import indigoengine.shared.datatypes.Radians
+
+/** `Quad`s are used when you want to draw a pixel accurate box, with or without individual rounded corners. Unlike
+  * `Shape.Box`, `Quad` does NOT support a `Stroke` (..though you can simulate it with another `Quad`), but it is pixel
+  * accurate* (as long as it is not rotated), allows you to define individual corner radii, and use either solid colors
+  * or gradient fills. An expected use-case would be drawing progress bars.
+  *
+  * (*`Shape.Box` can suffer from floating point errors due to the SDF based drawing method common to all `Shape`
+  * types.)
+  */
+final case class Quad(
+    dimensions: Rectangle,
+    fill: Fill,
+    corners: Corners,
+    lighting: LightingModel,
+    eventHandlerEnabled: Boolean,
+    eventHandler: ((Quad, GlobalEvent)) => Option[GlobalEvent],
+    rotation: Radians,
+    scale: Vector2,
+    ref: Point,
+    flip: Flip
+) extends EntityNode[Quad]
+    with Cloneable
+    with SpatialModifiers[Quad] derives CanEqual:
+
+  lazy val position: Point = dimensions.position
+  lazy val size: Size      = dimensions.size
+
+  def withDimensions(newDimensions: Rectangle): Quad =
+    this.copy(dimensions = newDimensions)
+
+  def withFill(newFill: Fill): Quad =
+    this.copy(fill = newFill)
+  def modifyFill(modifier: Fill => Fill): Quad =
+    this.copy(fill = modifier(fill))
+
+  def withCorners(newCorners: Corners): Quad =
+    this.copy(corners = newCorners)
+  def modifyCorners(modifier: Corners => Corners): Quad =
+    this.copy(corners = modifier(corners))
+
+  def withLighting(newLighting: LightingModel): Quad =
+    this.copy(lighting = newLighting)
+  def modifyLighting(modifier: LightingModel => LightingModel): Quad =
+    this.copy(lighting = modifier(lighting))
+
+  def moveTo(pt: Point): Quad =
+    this.copy(dimensions = dimensions.moveTo(pt))
+  def moveTo(x: Int, y: Int): Quad =
+    moveTo(Point(x, y))
+  def withPosition(newPosition: Point): Quad =
+    moveTo(newPosition)
+
+  def moveBy(pt: Point): Quad =
+    this.copy(dimensions = dimensions.moveBy(pt))
+  def moveBy(x: Int, y: Int): Quad =
+    moveBy(Point(x, y))
+
+  def rotateTo(angle: Radians): Quad =
+    this.copy(rotation = angle)
+  def rotateBy(angle: Radians): Quad =
+    rotateTo(rotation + angle)
+  def withRotation(newRotation: Radians): Quad =
+    rotateTo(newRotation)
+
+  def scaleBy(amount: Vector2): Quad =
+    this.copy(scale = scale * amount)
+  def scaleBy(x: Double, y: Double): Quad =
+    scaleBy(Vector2(x, y))
+  def withScale(newScale: Vector2): Quad =
+    this.copy(scale = newScale)
+
+  def transformTo(newPosition: Point, newRotation: Radians, newScale: Vector2): Quad =
+    this.copy(dimensions = dimensions.moveTo(newPosition), rotation = newRotation, scale = newScale)
+
+  def transformBy(positionDiff: Point, rotationDiff: Radians, scaleDiff: Vector2): Quad =
+    transformTo(position + positionDiff, rotation + rotationDiff, scale * scaleDiff)
+
+  def flipHorizontal(isFlipped: Boolean): Quad =
+    this.copy(flip = flip.withHorizontalFlip(isFlipped))
+  def flipVertical(isFlipped: Boolean): Quad =
+    this.copy(flip = flip.withVerticalFlip(isFlipped))
+  def withFlip(newFlip: Flip): Quad =
+    this.copy(flip = newFlip)
+
+  def withRef(newRef: Point): Quad =
+    this.copy(ref = newRef)
+  def withRef(x: Int, y: Int): Quad =
+    withRef(Point(x, y))
+
+  def resizeTo(newSize: Size): Quad =
+    this.copy(dimensions = dimensions.resize(newSize))
+  def resizeTo(width: Int, height: Int): Quad =
+    resizeTo(Size(width, height))
+  def withSize(newSize: Size): Quad =
+    resizeTo(newSize)
+
+  def resizeBy(amount: Size): Quad =
+    this.copy(dimensions = dimensions.resizeBy(amount))
+  def resizeBy(width: Int, height: Int): Quad =
+    resizeBy(Size(width, height))
+
+  def withEventHandler(f: ((Quad, GlobalEvent)) => Option[GlobalEvent]): Quad =
+    this.copy(eventHandler = f, eventHandlerEnabled = true)
+  def onEvent(f: PartialFunction[(Quad, GlobalEvent), GlobalEvent]): Quad =
+    withEventHandler(f.lift)
+  def enableEvents: Quad =
+    this.copy(eventHandlerEnabled = true)
+  def disableEvents: Quad =
+    this.copy(eventHandlerEnabled = false)
+
+  private def fillType(fill: Fill): Float =
+    fill match {
+      case _: Fill.Color          => 0.0f
+      case _: Fill.LinearGradient => 1.0f
+      case _: Fill.RadialGradient => 2.0f
+    }
+
+  def toShaderData: ShaderData =
+    val clampedCorners = corners.clampTo(size)
+
+    val shapeUniformBlock =
+      UniformBlock(
+        UniformBlockName("IndigoQuadData"),
+        // FILL_TYPE (float), 0.0 x3 (empty), CORNER_RADII (vec4)
+        Batch(
+          Uniform("Quad_DATA") -> ShaderPrimitive.rawBatch(
+            Batch[Float](
+              fillType(fill),
+              0.0,
+              0.0,
+              0.0,
+              clampedCorners.topLeft.toFloat,
+              clampedCorners.topRight.toFloat,
+              clampedCorners.bottomRight.toFloat,
+              clampedCorners.bottomLeft.toFloat
+            )
+          )
+        ) ++ UniformDataHelpers.fillToUniformData(fill, "QUAD")
+      )
+
+    lighting match {
+      case LightingModel.Unlit =>
+        ShaderData(
+          StandardShaders.Quad.id,
+          Batch(shapeUniformBlock)
+        )
+
+      case l: LightingModel.Lit =>
+        l.toShaderData(StandardShaders.LitQuad.id, None, Batch(shapeUniformBlock))
+    }
+
+object Quad:
+
+  def apply(dimensions: Rectangle, fill: Fill): Quad =
+    Quad(
+      dimensions,
+      fill,
+      Corners.zero,
+      LightingModel.Unlit,
+      false,
+      Function.const(None),
+      Radians.zero,
+      Vector2.one,
+      Point.zero,
+      Flip.default
+    )
+
+  def apply(dimensions: Rectangle, fill: Fill, corners: Corners): Quad =
+    Quad(
+      dimensions,
+      fill,
+      corners,
+      LightingModel.Unlit,
+      false,
+      Function.const(None),
+      Radians.zero,
+      Vector2.one,
+      Point.zero,
+      Flip.default
+    )

--- a/indigo-scenegraph/test/src/indigo/scenegraph/CornersTests.scala
+++ b/indigo-scenegraph/test/src/indigo/scenegraph/CornersTests.scala
@@ -1,0 +1,16 @@
+package indigo.scenegraph
+
+import indigo.core.datatypes.Size
+
+class CornersTests extends munit.FunSuite {
+
+  test("corner clamping") {
+    val corners = Corners(5, 10, 15, 20)
+
+    assertEquals(corners.clampTo(Size(50)), corners)
+    assertEquals(corners.clampTo(Size(32)), Corners(5, 10, 15, 16))
+    assertEquals(corners.clampTo(Size(20)), Corners(5, 10, 10, 10))
+    assertEquals(corners.clampTo(Size(1)), Corners(0, 0, 0, 0))
+  }
+
+}

--- a/indigo-shaders/src/indigo/shaders/StandardShaders.scala
+++ b/indigo-shaders/src/indigo/shaders/StandardShaders.scala
@@ -12,6 +12,8 @@ object StandardShaders {
       LitBitmapClip,
       ImageEffectsClip,
       LitImageEffectsClip,
+      Quad,
+      LitQuad,
       ShapeBox,
       LitShapeBox,
       ShapeCircle,
@@ -97,6 +99,34 @@ object StandardShaders {
   lazy val LitBitmapClip: UltravioletShader       = makeClipShader(LitBitmap)
   lazy val ImageEffectsClip: UltravioletShader    = makeClipShader(ImageEffects)
   lazy val LitImageEffectsClip: UltravioletShader = makeClipShader(LitImageEffects)
+
+  // Quad
+
+  lazy val Quad: UltravioletShader =
+    UltravioletShader(
+      ShaderId("[indigo_engine_quad]"),
+      EntityShader.vertex(library.NoOp.vertex, ()),
+      EntityShader.fragment(
+        library.Quad.fragment,
+        library.NoOp.prepare,
+        library.NoOp.light,
+        library.NoOp.composite,
+        library.Quad.Env.reference
+      )
+    )
+
+  lazy val LitQuad: UltravioletShader =
+    UltravioletShader(
+      ShaderId("[indigo_engine_lit_quad]"),
+      EntityShader.vertex(library.NoOp.vertex, ()),
+      EntityShader.fragment(
+        library.Quad.fragment,
+        library.Lighting.prepare,
+        library.Lighting.light,
+        library.Lighting.composite,
+        library.Quad.Env.reference
+      )
+    )
 
   // Shapes
 

--- a/indigo-shaders/src/indigo/shaders/library/Quad.scala
+++ b/indigo-shaders/src/indigo/shaders/library/Quad.scala
@@ -1,0 +1,105 @@
+package indigo.shaders.library
+
+import ultraviolet.syntax.*
+
+import scala.annotation.nowarn
+
+object Quad:
+
+  trait Env extends Lighting.LightEnv {
+    val FILL_TYPE: Float          = 0.0f
+    val CORNER_RADII: vec4        = vec4(0.0f)
+    val GRADIENT_FROM_TO: vec4    = vec4(0.0f)
+    val GRADIENT_FROM_COLOR: vec4 = vec4(0.0f)
+    val GRADIENT_TO_COLOR: vec4   = vec4(0.0f)
+  }
+  object Env:
+    val reference: Env = new Env {}
+
+  case class IndigoQuadData(
+      FILL_TYPE: Float,
+      EMPTY_1: Float,
+      EMPTY_2: Float,
+      EMPTY_3: Float,
+      CORNER_RADII: vec4,
+      GRADIENT_FROM_TO: vec4,
+      GRADIENT_FROM_COLOR: vec4,
+      GRADIENT_TO_COLOR: vec4
+  )
+
+  @nowarn("msg=unused")
+  @SuppressWarnings(Array("scalafix:DisableSyntax.var"))
+  inline def fragment =
+    Shader[Env] { env =>
+      import ShapeShaderFunctions.*
+
+      // Delegates
+      val _calculateLinearGradient: (vec2, vec2, vec2, vec4, vec4) => vec4 =
+        calculateLinearGradient
+      val _calculateRadialGradient: (vec2, vec2, vec2, vec4, vec4) => vec4 =
+        calculateRadialGradient
+
+      ubo[IndigoQuadData]
+
+      def insideBox(tl: vec2, br: vec2, p: vec2): Boolean =
+        p.x >= tl.x && p.x <= br.x && p.y >= tl.y && p.y <= br.y
+
+      def fragment(color: vec4): vec4 =
+        val fillType = round(env.FILL_TYPE).toInt
+        val fill: vec4 =
+          fillType match
+            case 1 =>
+              _calculateLinearGradient(
+                env.GRADIENT_FROM_TO.xy,
+                env.GRADIENT_FROM_TO.zw,
+                env.UV * env.SIZE,
+                env.GRADIENT_FROM_COLOR,
+                env.GRADIENT_TO_COLOR
+              )
+
+            case 2 =>
+              _calculateRadialGradient(
+                env.GRADIENT_FROM_TO.xy,
+                env.GRADIENT_FROM_TO.zw,
+                env.UV * env.SIZE,
+                env.GRADIENT_FROM_COLOR,
+                env.GRADIENT_TO_COLOR
+              )
+
+            case _ =>
+              env.GRADIENT_FROM_COLOR
+
+        // Dispose rules
+
+        val ctl = env.CORNER_RADII.x
+        val ctr = env.CORNER_RADII.y
+        val cbr = env.CORNER_RADII.z
+        val cbl = env.CORNER_RADII.w
+
+        val coords = env.UV * env.SIZE
+
+        var alpha = fill.a
+
+        // TL
+        if ctl > 0.0f && insideBox(vec2(0.0f), vec2(ctl), coords) && distance(coords, vec2(ctl)) > ctl then alpha = 0.0f
+
+        // TR
+        if ctr > 0.0f &&
+          insideBox(vec2(env.SIZE.x - ctr, 0.0f), vec2(env.SIZE.x, ctr), coords) &&
+          distance(coords, vec2(env.SIZE.x - ctr, ctr)) > ctr
+        then alpha = 0.0f
+
+        // BR
+        if cbr > 0.0f &&
+          insideBox(env.SIZE - cbr, env.SIZE, coords) &&
+          distance(coords, env.SIZE - vec2(cbr)) > cbr
+        then alpha = 0.0f
+
+        // BL
+        if cbl > 0.0f &&
+          insideBox(vec2(0.0f, env.SIZE.y - cbl), vec2(cbl, env.SIZE.y), coords) &&
+          distance(coords, vec2(cbl, env.SIZE.y - cbl)) > cbl
+        then alpha = 0.0f
+
+        vec4(fill.rgb * alpha, alpha)
+    }

--- a/indigo-shaders/test/src/indigo/shaders/StandardShadersTests.scala
+++ b/indigo-shaders/test/src/indigo/shaders/StandardShadersTests.scala
@@ -51,7 +51,7 @@ class StandardShadersTests extends munit.FunSuite {
     assert(StandardShaders.Quad.fragment.code.nonEmpty)
   }
 
-  test("QuadLit is valid") {
+  test("LitQuad is valid") {
     assert(StandardShaders.LitQuad.vertex.code.nonEmpty)
     assert(StandardShaders.LitQuad.fragment.code.nonEmpty)
   }

--- a/indigo-shaders/test/src/indigo/shaders/StandardShadersTests.scala
+++ b/indigo-shaders/test/src/indigo/shaders/StandardShadersTests.scala
@@ -46,6 +46,16 @@ class StandardShadersTests extends munit.FunSuite {
     assert(StandardShaders.LitImageEffectsClip.fragment.code.nonEmpty)
   }
 
+  test("Quad is valid") {
+    assert(StandardShaders.Quad.vertex.code.nonEmpty)
+    assert(StandardShaders.Quad.fragment.code.nonEmpty)
+  }
+
+  test("QuadLit is valid") {
+    assert(StandardShaders.LitQuad.vertex.code.nonEmpty)
+    assert(StandardShaders.LitQuad.fragment.code.nonEmpty)
+  }
+
   test("ShapeBox is valid") {
     assert(StandardShaders.ShapeBox.vertex.code.nonEmpty)
     assert(StandardShaders.ShapeBox.fragment.code.nonEmpty)

--- a/indigo/src/indigo/package.scala
+++ b/indigo/src/indigo/package.scala
@@ -490,6 +490,12 @@ object aliases:
   type ClipPlayMode = indigo.scenegraph.ClipPlayMode
   val ClipPlayMode: indigo.scenegraph.ClipPlayMode.type = indigo.scenegraph.ClipPlayMode
 
+  type Quad = indigo.scenegraph.Quad
+  val Quad: indigo.scenegraph.Quad.type = indigo.scenegraph.Quad
+
+  type Corners = indigo.scenegraph.Corners
+  val Corners: indigo.scenegraph.Corners.type = indigo.scenegraph.Corners
+
   // Clones
   type Cloneable = indigo.scenegraph.Cloneable
 


### PR DESCRIPTION
Relates to https://github.com/PurpleKingdomGames/indigoengine/issues/252

Allows the user to draw simple pixel accurate boxes with individual corners and a choice of fills.
<img width="819" height="647" alt="image" src="https://github.com/user-attachments/assets/da369593-c9d6-4e0a-9680-120463655b01" />
