### PR TITLE
FIXED #273: Remove redundant shaderId overrides

### DIFF
--- a/indigo-scenegraph/src/indigo/scenegraph/Shape.scala
+++ b/indigo-scenegraph/src/indigo/scenegraph/Shape.scala
@@ -14,7 +14,6 @@ import indigo.scenegraph.materials.LightingModel.Lit
 import indigo.scenegraph.materials.LightingModel.Unlit
 import indigo.scenegraph.registers.BoundaryLocator
 import indigo.shaders.ShaderData
-import indigo.shaders.ShaderId
 import indigo.shaders.ShaderPrimitive.*
 import indigo.shaders.StandardShaders
 import indigo.shaders.Uniform
@@ -69,8 +68,7 @@ object Shape:
       rotation: Radians,
       scale: Vector2,
       ref: Point,
-      flip: Flip,
-      shaderId: Option[ShaderId]
+      flip: Flip
   ) extends Shape[Box] {
 
     override def accept[A](visitor: SceneNodeVisitor[A]): A =
@@ -152,9 +150,6 @@ object Shape:
     def withFlip(newFlip: Flip): Box =
       this.copy(flip = newFlip)
 
-    def withShaderId(newShaderId: ShaderId): Box =
-      this.copy(shaderId = Option(newShaderId))
-
     def withEventHandler(f: ((Box, GlobalEvent)) => Option[GlobalEvent]): Box =
       this.copy(eventHandler = f, eventHandlerEnabled = true)
     def onEvent(f: PartialFunction[(Box, GlobalEvent), GlobalEvent]): Box =
@@ -177,8 +172,7 @@ object Shape:
         Radians.zero,
         Vector2.one,
         Point.zero,
-        Flip.default,
-        None
+        Flip.default
       )
 
     def apply(dimensions: Rectangle, fill: Fill, stroke: Stroke): Box =
@@ -192,8 +186,7 @@ object Shape:
         Radians.zero,
         Vector2.one,
         Point.zero,
-        Flip.default,
-        None
+        Flip.default
       )
 
   }
@@ -210,8 +203,7 @@ object Shape:
       rotation: Radians,
       scale: Vector2,
       ref: Point,
-      flip: Flip,
-      shaderId: Option[ShaderId]
+      flip: Flip
   ) extends Shape[Circle] {
 
     override def accept[A](visitor: SceneNodeVisitor[A]): A =
@@ -294,9 +286,6 @@ object Shape:
     def withFlip(newFlip: Flip): Circle =
       this.copy(flip = newFlip)
 
-    def withShaderId(newShaderId: ShaderId): Circle =
-      this.copy(shaderId = Option(newShaderId))
-
     def withEventHandler(f: ((Circle, GlobalEvent)) => Option[GlobalEvent]): Circle =
       this.copy(eventHandler = f, eventHandlerEnabled = true)
     def onEvent(f: PartialFunction[(Circle, GlobalEvent), GlobalEvent]): Circle =
@@ -320,8 +309,7 @@ object Shape:
         Radians.zero,
         Vector2.one,
         Point.zero,
-        Flip.default,
-        None
+        Flip.default
       )
 
     def apply(circle: C, fill: Fill): Circle =
@@ -335,8 +323,7 @@ object Shape:
         Radians.zero,
         Vector2.one,
         Point.zero,
-        Flip.default,
-        None
+        Flip.default
       )
 
     def apply(center: Point, radius: Int, fill: Fill, stroke: Stroke): Circle =
@@ -350,8 +337,7 @@ object Shape:
         Radians.zero,
         Vector2.one,
         Point.zero,
-        Flip.default,
-        None
+        Flip.default
       )
 
     def apply(circle: C, fill: Fill, stroke: Stroke): Circle =
@@ -365,8 +351,7 @@ object Shape:
         Radians.zero,
         Vector2.one,
         Point.zero,
-        Flip.default,
-        None
+        Flip.default
       )
 
   }
@@ -383,8 +368,7 @@ object Shape:
       rotation: Radians,
       scale: Vector2,
       ref: Point,
-      flip: Flip,
-      shaderId: Option[ShaderId]
+      flip: Flip
   ) extends Shape[Line] {
 
     override def accept[A](visitor: SceneNodeVisitor[A]): A =
@@ -480,9 +464,6 @@ object Shape:
     def withFlip(newFlip: Flip): Line =
       this.copy(flip = newFlip)
 
-    def withShaderId(newShaderId: ShaderId): Line =
-      this.copy(shaderId = Option(newShaderId))
-
     def withEventHandler(f: ((Line, GlobalEvent)) => Option[GlobalEvent]): Line =
       this.copy(eventHandler = f, eventHandlerEnabled = true)
     def onEvent(f: PartialFunction[(Line, GlobalEvent), GlobalEvent]): Line =
@@ -505,8 +486,7 @@ object Shape:
         Radians.zero,
         Vector2.one,
         Point.zero,
-        Flip.default,
-        None
+        Flip.default
       )
 
   }
@@ -523,8 +503,7 @@ object Shape:
       rotation: Radians,
       scale: Vector2,
       ref: Point,
-      flip: Flip,
-      shaderId: Option[ShaderId]
+      flip: Flip
   ) extends Shape[Polygon] {
 
     override def accept[A](visitor: SceneNodeVisitor[A]): A =
@@ -607,9 +586,6 @@ object Shape:
     def withFlip(newFlip: Flip): Polygon =
       this.copy(flip = newFlip)
 
-    def withShaderId(newShaderId: ShaderId): Polygon =
-      this.copy(shaderId = Option(newShaderId))
-
     def withEventHandler(f: ((Polygon, GlobalEvent)) => Option[GlobalEvent]): Polygon =
       this.copy(eventHandler = f, eventHandlerEnabled = true)
     def onEvent(f: PartialFunction[(Polygon, GlobalEvent), GlobalEvent]): Polygon =
@@ -633,8 +609,7 @@ object Shape:
         Radians.zero,
         Vector2.one,
         Point.zero,
-        Flip.default,
-        None
+        Flip.default
       )
 
     def apply(vertices: Batch[Point], fill: Fill, stroke: Stroke): Polygon =
@@ -648,8 +623,7 @@ object Shape:
         Radians.zero,
         Vector2.one,
         Point.zero,
-        Flip.default,
-        None
+        Flip.default
       )
 
     def apply(fill: Fill, stroke: Stroke)(vertices: Point*): Polygon =
@@ -663,8 +637,7 @@ object Shape:
         Radians.zero,
         Vector2.one,
         Point.zero,
-        Flip.default,
-        None
+        Flip.default
       )
 
   }
@@ -714,12 +687,12 @@ object Shape:
         s.lighting match {
           case Unlit =>
             ShaderData(
-              s.shaderId.getOrElse(StandardShaders.ShapeBox.id),
+              StandardShaders.ShapeBox.id,
               Batch(shapeUniformBlock)
             )
 
           case l: Lit =>
-            l.toShaderData(s.shaderId.getOrElse(StandardShaders.LitShapeBox.id), None, Batch(shapeUniformBlock))
+            l.toShaderData(StandardShaders.LitShapeBox.id, None, Batch(shapeUniformBlock))
         }
 
       case s: Shape.Circle =>
@@ -746,12 +719,12 @@ object Shape:
         s.lighting match {
           case Unlit =>
             ShaderData(
-              s.shaderId.getOrElse(StandardShaders.ShapeCircle.id),
+              StandardShaders.ShapeCircle.id,
               Batch(shapeUniformBlock)
             )
 
           case l: Lit =>
-            l.toShaderData(s.shaderId.getOrElse(StandardShaders.LitShapeCircle.id), None, Batch(shapeUniformBlock))
+            l.toShaderData(StandardShaders.LitShapeCircle.id, None, Batch(shapeUniformBlock))
         }
 
       case s: Shape.Line =>
@@ -792,12 +765,12 @@ object Shape:
         s.lighting match {
           case Unlit =>
             ShaderData(
-              s.shaderId.getOrElse(StandardShaders.ShapeLine.id),
+              StandardShaders.ShapeLine.id,
               Batch(shapeUniformBlock)
             )
 
           case l: Lit =>
-            l.toShaderData(s.shaderId.getOrElse(StandardShaders.LitShapeLine.id), None, Batch(shapeUniformBlock))
+            l.toShaderData(StandardShaders.LitShapeLine.id, None, Batch(shapeUniformBlock))
         }
 
       case s: Shape.Polygon =>
@@ -840,12 +813,12 @@ object Shape:
         s.lighting match {
           case Unlit =>
             ShaderData(
-              s.shaderId.getOrElse(StandardShaders.ShapePolygon.id),
+              StandardShaders.ShapePolygon.id,
               Batch(shapeUniformBlock)
             )
 
           case l: Lit =>
-            l.toShaderData(s.shaderId.getOrElse(StandardShaders.LitShapePolygon.id), None, Batch(shapeUniformBlock))
+            l.toShaderData(StandardShaders.LitShapePolygon.id, None, Batch(shapeUniformBlock))
         }
 
 end Shape

--- a/indigo-scenegraph/src/indigo/scenegraph/materials/Material.scala
+++ b/indigo-scenegraph/src/indigo/scenegraph/materials/Material.scala
@@ -6,7 +6,6 @@ import indigo.core.datatypes.Rectangle
 import indigo.scenegraph.materials.LightingModel.Lit
 import indigo.scenegraph.materials.LightingModel.Unlit
 import indigo.shaders.ShaderData
-import indigo.shaders.ShaderId
 import indigo.shaders.ShaderPrimitive.rawBatch
 import indigo.shaders.StandardShaders
 import indigo.shaders.Uniform
@@ -22,8 +21,8 @@ trait Material:
 
 object Material:
 
-  final case class Bitmap(diffuse: AssetName, lighting: LightingModel, shaderId: Option[ShaderId], fillType: FillType)
-      extends Material derives CanEqual:
+  final case class Bitmap(diffuse: AssetName, lighting: LightingModel, fillType: FillType) extends Material
+      derives CanEqual:
 
     def withDiffuse(newDiffuse: AssetName): Bitmap =
       this.copy(diffuse = newDiffuse)
@@ -37,9 +36,6 @@ object Material:
       withLighting(lighting.enableLighting)
     def disableLighting: Bitmap =
       withLighting(lighting.disableLighting)
-
-    def withShaderId(newShaderId: ShaderId): Bitmap =
-      this.copy(shaderId = Option(newShaderId))
 
     def withFillType(newFillType: FillType): Bitmap =
       this.copy(fillType = newFillType)
@@ -62,7 +58,6 @@ object Material:
         Fill.Color.default,
         1.0,
         lighting,
-        shaderId,
         fillType
       )
 
@@ -102,7 +97,7 @@ object Material:
       lighting match
         case Unlit =>
           ShaderData(
-            shaderId.getOrElse(StandardShaders.Bitmap.id),
+            StandardShaders.Bitmap.id,
             Batch(uniformBlock),
             Some(diffuse),
             None,
@@ -111,14 +106,14 @@ object Material:
           )
 
         case l: Lit =>
-          l.toShaderData(shaderId.getOrElse(StandardShaders.LitBitmap.id), Some(diffuse), Batch(uniformBlock))
+          l.toShaderData(StandardShaders.LitBitmap.id, Some(diffuse), Batch(uniformBlock))
 
   object Bitmap:
     def apply(diffuse: AssetName): Bitmap =
-      Bitmap(diffuse, LightingModel.Unlit, None, FillType.Normal)
+      Bitmap(diffuse, LightingModel.Unlit, FillType.Normal)
 
     def apply(diffuse: AssetName, lighting: LightingModel): Bitmap =
-      Bitmap(diffuse, lighting, None, FillType.Normal)
+      Bitmap(diffuse, lighting, FillType.Normal)
 
   final case class ImageEffects(
       diffuse: AssetName,
@@ -127,7 +122,6 @@ object Material:
       overlay: Fill,
       saturation: Double,
       lighting: LightingModel,
-      shaderId: Option[ShaderId],
       fillType: FillType
   ) extends Material derives CanEqual:
 
@@ -158,9 +152,6 @@ object Material:
     def disableLighting: ImageEffects =
       withLighting(lighting.disableLighting)
 
-    def withShaderId(newShaderId: ShaderId): ImageEffects =
-      this.copy(shaderId = Option(newShaderId))
-
     def withFillType(newFillType: FillType): ImageEffects =
       this.copy(fillType = newFillType)
     def normal: ImageEffects =
@@ -175,7 +166,7 @@ object Material:
       withFillType(FillType.NineSlice(top, right, bottom, left))
 
     def toBitmap: Material.Bitmap =
-      Material.Bitmap(diffuse, lighting, shaderId, fillType)
+      Material.Bitmap(diffuse, lighting, fillType)
 
     lazy val toShaderData: ShaderData =
       val overlayType: Float =
@@ -231,7 +222,7 @@ object Material:
       lighting match
         case Unlit =>
           ShaderData(
-            shaderId.getOrElse(StandardShaders.ImageEffects.id),
+            StandardShaders.ImageEffects.id,
             Batch(effectsUniformBlock),
             Some(diffuse),
             None,
@@ -241,26 +232,23 @@ object Material:
 
         case l: Lit =>
           l.toShaderData(
-            shaderId.getOrElse(StandardShaders.LitImageEffects.id),
+            StandardShaders.LitImageEffects.id,
             Some(diffuse),
             Batch(effectsUniformBlock)
           )
 
   object ImageEffects:
     def apply(diffuse: AssetName): ImageEffects =
-      ImageEffects(diffuse, 1.0, RGBA.None, Fill.Color.default, 1.0, LightingModel.Unlit, None, FillType.Normal)
+      ImageEffects(diffuse, 1.0, RGBA.None, Fill.Color.default, 1.0, LightingModel.Unlit, FillType.Normal)
 
     def alpha(diffuse: AssetName, value: Double): ImageEffects =
-      ImageEffects(diffuse, value, RGBA.None, Fill.Color.default, 1.0, LightingModel.Unlit, None, FillType.Normal)
+      ImageEffects(diffuse, value, RGBA.None, Fill.Color.default, 1.0, LightingModel.Unlit, FillType.Normal)
     def tint(diffuse: AssetName, value: RGBA): ImageEffects =
-      ImageEffects(diffuse, 1.0, value, Fill.Color.default, 1.0, LightingModel.Unlit, None, FillType.Normal)
+      ImageEffects(diffuse, 1.0, value, Fill.Color.default, 1.0, LightingModel.Unlit, FillType.Normal)
     def overlay(diffuse: AssetName, value: Fill): ImageEffects =
-      ImageEffects(diffuse, 1.0, RGBA.None, value, 1.0, LightingModel.Unlit, None, FillType.Normal)
+      ImageEffects(diffuse, 1.0, RGBA.None, value, 1.0, LightingModel.Unlit, FillType.Normal)
     def saturation(diffuse: AssetName, value: Double): ImageEffects =
-      ImageEffects(diffuse, 1.0, RGBA.None, Fill.Color.default, value, LightingModel.Unlit, None, FillType.Normal)
+      ImageEffects(diffuse, 1.0, RGBA.None, Fill.Color.default, value, LightingModel.Unlit, FillType.Normal)
 
     def apply(diffuse: AssetName, lighting: LightingModel): ImageEffects =
-      ImageEffects(diffuse, 1.0, RGBA.None, Fill.Color.default, 1.0, lighting, None, FillType.Normal)
-
-    def apply(diffuse: AssetName, lighting: LightingModel, shaderId: Option[ShaderId]): ImageEffects =
-      ImageEffects(diffuse, 1.0, RGBA.None, Fill.Color.default, 1.0, lighting, shaderId, FillType.Normal)
+      ImageEffects(diffuse, 1.0, RGBA.None, Fill.Color.default, 1.0, lighting, FillType.Normal)

--- a/roguelike-starterkit-demo/src/demo/RogueLikeGame.scala
+++ b/roguelike-starterkit-demo/src/demo/RogueLikeGame.scala
@@ -39,9 +39,7 @@ final class RogueLikeGame() extends Game[Unit, Unit, GameModel]:
         .withAssets(Assets.assets.assetSetRelative)
         .withShaders(
           indigoextras.ui.shaders.all ++
-            roguelikestarterkit.shaders.all ++ Set(
-              TerminalTextScene.customShader(ShaderId("my shader"))
-            )
+            roguelikestarterkit.shaders.all
         )
         .withSubSystems(
           FPSCounter(

--- a/roguelike-starterkit-demo/src/demo/scenes/TerminalTextScene.scala
+++ b/roguelike-starterkit-demo/src/demo/scenes/TerminalTextScene.scala
@@ -6,8 +6,6 @@ import demo.models.GameModel
 import indigo.*
 import roguelikestarterkit.*
 
-import scala.annotation.nowarn
-
 object TerminalTextScene extends Scene[GameModel]:
 
   type SceneModel = GameModel
@@ -52,69 +50,13 @@ object TerminalTextScene extends Scene[GameModel]:
           Text(
             message,
             RoguelikeTiles.Size10x10.Fonts.fontKey,
-            TerminalText(Assets.assets.AnikkiSquare10x10, RGBA.Yellow, RGBA.Red)
-              .withShaderId(ShaderId("my shader"))
-          ).moveBy(0, 40),
-          Text(
-            message,
-            RoguelikeTiles.Size10x10.Fonts.fontKey,
             TerminalText(
               Assets.assets.AnikkiSquare10x10,
               RGBA.White,
               RGBA.Zero,
               RGBA.Magenta.withAlpha(0.75)
             )
-          ).moveBy(0, 80)
+          ).moveBy(0, 40)
         )
       ).withMagnification(Magnification.x2)
     )
-
-  def customShader(shaderId: ShaderId): UltravioletShader =
-    UltravioletShader.entityFragment(
-      shaderId,
-      EntityShader.fragment[ShaderImpl.Env](
-        ShaderImpl.frag,
-        ShaderImpl.Env.ref
-      )
-    )
-
-  object ShaderImpl:
-
-    import ultraviolet.syntax.*
-
-    final case class Env(
-        FOREGROUND: vec3,
-        BACKGROUND: vec4,
-        MASK: vec4
-    ) extends FragmentEnvReference
-
-    object Env:
-      val ref =
-        Env(vec3(0.0f), vec4(0.0f), vec4(0.0f))
-
-    final case class RogueLikeTextData(
-        FOREGROUND: vec3,
-        BACKGROUND: vec4,
-        MASK: vec4
-    )
-
-    @nowarn("msg=unused")
-    inline def frag: Shader[Env, Unit] =
-      Shader[Env] { env =>
-        ubo[RogueLikeTextData]
-
-        def fragment(color: vec4): vec4 =
-          val maskDiff: Boolean = abs(env.CHANNEL_0.x - env.MASK.x) < 0.001f &&
-            abs(env.CHANNEL_0.y - env.MASK.y) < 0.001f &&
-            abs(env.CHANNEL_0.z - env.MASK.z) < 0.001f &&
-            abs(env.CHANNEL_0.w - env.MASK.w) < 0.001f
-
-          val c: vec4 =
-            if (maskDiff) {
-              env.BACKGROUND
-            } else {
-              vec4(env.CHANNEL_0.rgb * (env.FOREGROUND.rgb * env.CHANNEL_0.a), env.CHANNEL_0.a)
-            }
-
-          c * (1.0f - (vec4(env.SCREEN_COORDS.x) / 250.0f)) // Example custom mod
-      }

--- a/roguelike-starterkit/src/roguelikestarterkit/terminal/TerminalMaterial.scala
+++ b/roguelike-starterkit/src/roguelikestarterkit/terminal/TerminalMaterial.scala
@@ -14,8 +14,7 @@ final case class TerminalMaterial(
     foreground: RGBA,
     background: RGBA,
     mask: RGBA,
-    lighting: LightingModel,
-    shaderId: Option[ShaderId]
+    lighting: LightingModel
 ) extends Material:
 
   def withColors(newForeground: RGBA, newBackground: RGBA): TerminalMaterial =
@@ -48,9 +47,6 @@ final case class TerminalMaterial(
   def disableLighting: TerminalMaterial =
     withLighting(lighting.disableLighting)
 
-  def withShaderId(newShaderId: ShaderId): TerminalMaterial =
-    this.copy(shaderId = Option(newShaderId))
-
   def toShaderData: ShaderData =
     val uniformBlock =
       UniformBlock(
@@ -65,7 +61,7 @@ final case class TerminalMaterial(
     lighting match
       case LightingModel.Unlit =>
         ShaderData(
-          shaderId.getOrElse(TerminalMaterial.shaderId),
+          TerminalMaterial.shaderId,
           Batch(uniformBlock),
           Some(tileMap),
           None,
@@ -75,7 +71,7 @@ final case class TerminalMaterial(
 
       case l: LightingModel.Lit =>
         l.toShaderData(
-          shaderId.getOrElse(TerminalMaterial.litShaderId),
+          TerminalMaterial.litShaderId,
           Some(tileMap),
           Batch(uniformBlock)
         )
@@ -116,13 +112,13 @@ object TerminalMaterial:
     Set(standardShader, standardShaderLit)
 
   def apply(tileMap: AssetName): TerminalMaterial =
-    TerminalMaterial(tileMap, RGBA.White, RGBA.Zero, defaultMask, LightingModel.Unlit, None)
+    TerminalMaterial(tileMap, RGBA.White, RGBA.Zero, defaultMask, LightingModel.Unlit)
 
   def apply(tileMap: AssetName, color: RGBA): TerminalMaterial =
-    TerminalMaterial(tileMap, color, RGBA.Zero, defaultMask, LightingModel.Unlit, None)
+    TerminalMaterial(tileMap, color, RGBA.Zero, defaultMask, LightingModel.Unlit)
 
   def apply(tileMap: AssetName, foreground: RGBA, background: RGBA): TerminalMaterial =
-    TerminalMaterial(tileMap, foreground, background, defaultMask, LightingModel.Unlit, None)
+    TerminalMaterial(tileMap, foreground, background, defaultMask, LightingModel.Unlit)
 
   def apply(
       tileMap: AssetName,
@@ -130,16 +126,7 @@ object TerminalMaterial:
       background: RGBA,
       mask: RGBA
   ): TerminalMaterial =
-    TerminalMaterial(tileMap, foreground, background, mask, LightingModel.Unlit, None)
-
-  def apply(
-      tileMap: AssetName,
-      foreground: RGBA,
-      background: RGBA,
-      mask: RGBA,
-      lightingModel: LightingModel
-  ): TerminalMaterial =
-    TerminalMaterial(tileMap, foreground, background, mask, lightingModel, None)
+    TerminalMaterial(tileMap, foreground, background, mask, LightingModel.Unlit)
 
   object ShaderImpl:
 

--- a/roguelike-starterkit/src/roguelikestarterkit/terminal/TerminalText.scala
+++ b/roguelike-starterkit/src/roguelikestarterkit/terminal/TerminalText.scala
@@ -12,8 +12,7 @@ final case class TerminalText(
     foreground: RGBA,
     background: RGBA,
     shadow: RGBA,
-    mask: RGBA,
-    shaderId: Option[ShaderId]
+    mask: RGBA
 ) extends Material:
 
   def withColors(newForeground: RGBA, newBackground: RGBA): TerminalText =
@@ -41,12 +40,9 @@ final case class TerminalText(
   def withMask(newColor: RGB): TerminalText =
     withMask(newColor.toRGBA)
 
-  def withShaderId(newShaderId: ShaderId): TerminalText =
-    this.copy(shaderId = Option(newShaderId))
-
   def toShaderData: ShaderData =
     ShaderData(
-      shaderId.getOrElse(TerminalText.shaderId),
+      TerminalText.shaderId,
       Batch(
         UniformBlock(
           UniformBlockName("RogueLikeTextData"),
@@ -86,25 +82,16 @@ object TerminalText:
     )
 
   def apply(tileMap: AssetName): TerminalText =
-    TerminalText(tileMap, RGBA.White, RGBA.Zero, RGBA.Zero, defaultMask, None)
+    TerminalText(tileMap, RGBA.White, RGBA.Zero, RGBA.Zero, defaultMask)
 
   def apply(tileMap: AssetName, color: RGBA): TerminalText =
-    TerminalText(tileMap, color, RGBA.Zero, RGBA.Zero, defaultMask, None)
+    TerminalText(tileMap, color, RGBA.Zero, RGBA.Zero, defaultMask)
 
   def apply(tileMap: AssetName, foreground: RGBA, background: RGBA): TerminalText =
-    TerminalText(tileMap, foreground, background, background, defaultMask, None)
+    TerminalText(tileMap, foreground, background, background, defaultMask)
 
   def apply(tileMap: AssetName, foreground: RGBA, background: RGBA, shadow: RGBA): TerminalText =
-    TerminalText(tileMap, foreground, background, shadow, defaultMask, None)
-
-  def apply(
-      tileMap: AssetName,
-      foreground: RGBA,
-      background: RGBA,
-      shadow: RGBA,
-      mask: RGBA
-  ): TerminalText =
-    TerminalText(tileMap, foreground, background, shadow, mask, None)
+    TerminalText(tileMap, foreground, background, shadow, defaultMask)
 
   object ShaderImpl:
 


### PR DESCRIPTION
Relates to https://github.com/PurpleKingdomGames/indigoengine/issues/273

This is a breaking API change, but that's ok.

Long ago, back in the mists of time, I thought it would be fun to allow people to - for any given primitive - plug in a replacement shader. Cute but short sighted. The truth is that if you want to replace the shader on a primitive, it's really difficult, because you have to know all about the original rendering process, by which time, you'd be better off just doing something custom (probably).

In any case, I've never had cause to use this functionality, and I seriously doubt anyone else has either, so we might as well clean up the API's a little.