### PR TITLE
FIXED #278: UV modules bugs with Int / mixed types

### DIFF
--- a/ultraviolet/src/ultraviolet/datatypes/ProceduralShader.scala
+++ b/ultraviolet/src/ultraviolet/datatypes/ProceduralShader.scala
@@ -50,6 +50,11 @@ final case class ProceduralShader(
             ShaderAST.CallFunction(to, args, returnType)
         }
 
+        // Every `%` in the AST is an integer modulus - float modulus is emitted as a call to `mod`.
+        case ProgramTransformer.ExpandIntegerModulus => { case ShaderAST.Infix("%", l, r, rt) =>
+          ShaderAST.Infix("-", l, ShaderAST.Infix("*", r, ShaderAST.Infix("/", l, r, rt), rt), rt)
+        }
+
         case ProgramTransformer.AnnotateFunctionArgument(functionName, argumentName, annotation) => {
           case fn @ ShaderAST.Function(
                 fnName,

--- a/ultraviolet/src/ultraviolet/datatypes/ProgramTransformer.scala
+++ b/ultraviolet/src/ultraviolet/datatypes/ProgramTransformer.scala
@@ -35,6 +35,12 @@ enum ProgramTransformer derives CanEqual:
     */
   case StripUBOPrecisionQualifiers
 
+  /** Rewrite integer modulus `a % b` as `a - b * (a / b)`. GLSL ES 1.00 reserves the `%` operator but does not
+    * implement it, and `mod` is float only. Integer division truncates towards zero in GLSL, just as it does in Scala,
+    * so the two forms agree.
+    */
+  case ExpandIntegerModulus
+
 object ProgramTransformer:
 
   given ToExpr[ProgramTransformer] with {
@@ -68,6 +74,9 @@ object ProgramTransformer:
 
         case ProgramTransformer.StripUBOPrecisionQualifiers =>
           '{ ProgramTransformer.StripUBOPrecisionQualifiers }
+
+        case ProgramTransformer.ExpandIntegerModulus =>
+          '{ ProgramTransformer.ExpandIntegerModulus }
   }
 
   given FromExpr[ProgramTransformer] with
@@ -127,6 +136,12 @@ object ProgramTransformer:
         case Ident("StripUBOPrecisionQualifiers") =>
           Some(ProgramTransformer.StripUBOPrecisionQualifiers)
 
+        case Select(Ident("ProgramTransformer"), "ExpandIntegerModulus") =>
+          Some(ProgramTransformer.ExpandIntegerModulus)
+
+        case Ident("ExpandIntegerModulus") =>
+          Some(ProgramTransformer.ExpandIntegerModulus)
+
         case e =>
           report.errorAndAbort(s"[Ultraviolet macro error, please report.] ProgramTransformer after unwrap expr:\n${e
               .show(using Printer.TreeStructure)}")
@@ -135,7 +150,8 @@ object ProgramTransformer:
   inline def GLSL_100: List[ProgramTransformer] =
     List(
       ProgramTransformer.RenameAnnotation("in", "varying"),
-      ProgramTransformer.RenameAnnotation("out", "varying")
+      ProgramTransformer.RenameAnnotation("out", "varying"),
+      ProgramTransformer.ExpandIntegerModulus
     )
 
   inline def GLSL_300: List[ProgramTransformer] =

--- a/ultraviolet/src/ultraviolet/macros/CreateShaderAST.scala
+++ b/ultraviolet/src/ultraviolet/macros/CreateShaderAST.scala
@@ -28,48 +28,61 @@ class CreateShaderAST[Q <: Quotes](using val qq: Q) extends ShaderMacroUtils:
       case l =>
         throw ShaderError.Unsupported(s"Swizzle of length $l found, which is greater than the max length of 4.")
 
-  def extractInferredType(typ: TypeTree): String =
-    def mapName(name: String): String =
-      Option(name)
-        .map {
-          case "Boolean"      => "bool"
-          case "Float"        => "float"
-          case "Int"          => "int"
-          case "vec2"         => "vec2"
-          case "vec3"         => "vec3"
-          case "vec4"         => "vec4"
-          case "bvec2"        => "bvec2"
-          case "bvec3"        => "bvec3"
-          case "bvec4"        => "bvec4"
-          case "ivec2"        => "ivec2"
-          case "ivec3"        => "ivec3"
-          case "ivec4"        => "ivec4"
-          case "mat2"         => "mat2"
-          case "mat3"         => "mat3"
-          case "mat4"         => "mat4"
-          case "sampler2D$"   => "sampler2D"
-          case "samplerCube$" => "samplerCube"
-          case n              => n
-        }
-        .filterNot {
-          case "Unit" | "array" | "Any" =>
-            true
-          case n if n.startsWith("Function") =>
-            true
-          case _ =>
-            false
-        }
-        .getOrElse("void")
+  def mapTypeName(name: String): String =
+    Option(name)
+      .map {
+        case "Boolean"      => "bool"
+        case "Float"        => "float"
+        case "Int"          => "int"
+        case "vec2"         => "vec2"
+        case "vec3"         => "vec3"
+        case "vec4"         => "vec4"
+        case "bvec2"        => "bvec2"
+        case "bvec3"        => "bvec3"
+        case "bvec4"        => "bvec4"
+        case "ivec2"        => "ivec2"
+        case "ivec3"        => "ivec3"
+        case "ivec4"        => "ivec4"
+        case "mat2"         => "mat2"
+        case "mat3"         => "mat3"
+        case "mat4"         => "mat4"
+        case "sampler2D$"   => "sampler2D"
+        case "samplerCube$" => "samplerCube"
+        case n              => n
+      }
+      .filterNot {
+        case "Unit" | "array" | "Any" =>
+          true
+        case n if n.startsWith("Function") =>
+          true
+        case _ =>
+          false
+      }
+      .getOrElse("void")
 
+  /** The GLSL type name of a term, based on its Scala type. Unlike `ShaderAST.typeIdent`, this can see through a plain
+    * identifier to the type of the thing it refers to.
+    */
+  def extractInferredTypeOfTerm(term: Term): String =
+    mapTypeName(term.tpe.widen.classSymbol.map(_.name).getOrElse("void"))
+
+  def checkOperandTypes(op: String, lhsTerm: Term, rhsTerm: Option[Term]): Unit =
+    val lhsType = extractInferredTypeOfTerm(lhsTerm)
+    val rhsType = rhsTerm.map(extractInferredTypeOfTerm).getOrElse("void")
+
+    if isMixedNumericOperands(lhsType, rhsType) then
+      throw ShaderError.Unsupported(mixedNumericOperandsMsg(op, lhsType, rhsType))
+
+  def extractInferredType(typ: TypeTree): String =
     typ match
       case Applied(TypeIdent("array"), List(Singleton(Literal(IntConstant(size))), TypeIdent(typeName))) =>
-        mapName(typeName) + s"[${size.toString()}]"
+        mapTypeName(typeName) + s"[${size.toString()}]"
 
       case Applied(TypeIdent("array"), List(Singleton(Ident(varName)), TypeIdent(typeName))) =>
-        mapName(typeName) + s"[$varName]"
+        mapTypeName(typeName) + s"[$varName]"
 
       case _ =>
-        val res = mapName(typ.tpe.classSymbol.map(_.name).getOrElse("void"))
+        val res = mapTypeName(typ.tpe.classSymbol.map(_.name).getOrElse("void"))
 
         res match
           case "void" =>
@@ -78,7 +91,7 @@ class CreateShaderAST[Q <: Quotes](using val qq: Q) extends ShaderMacroUtils:
             if typ.tpe.show.contains("Shader") then
               typ.tpe.typeArgs.lastOption match
                 case Some(TypeRef(_, value)) =>
-                  mapName(value)
+                  mapTypeName(value)
 
                 case _ =>
                   res
@@ -522,6 +535,35 @@ class CreateShaderAST[Q <: Quotes](using val qq: Q) extends ShaderMacroUtils:
       case x =>
         val sample = Printer.TreeStructure.show(x).take(100)
         throw ShaderError.UnexpectedConstruction("Unexpected Tree: " + sample + "(..)")
+
+  /** GLSL's `mod` is float only, integers must use the `%` operator. The ShaderAST cannot type a bare identifier - it
+    * reports the variable's name rather than its type - so the operands' Scala types are the reliable signal here, with
+    * the AST as a fallback for anything they cannot resolve.
+    */
+  def walkModulus(lhsTerm: Term, rhsTerm: Option[Term], envVarName: Option[String]): ShaderAST =
+    val lhs = walkTerm(lhsTerm, envVarName)
+    val rhs = rhsTerm.map(t => walkTerm(t, envVarName)).getOrElse(ShaderAST.Empty())
+
+    checkOperandTypes("%", lhsTerm, rhsTerm)
+
+    val inferred = extractInferredTypeOfTerm(lhsTerm)
+
+    val rt =
+      if inferred == "void" then findReturnType(lhs)
+      else ShaderAST.DataTypes.ident(inferred)
+
+    val isInt =
+      inferred == "int" ||
+        rhsTerm.exists(t => extractInferredTypeOfTerm(t) == "int") ||
+        List(lhs.typeIdent, rhs.typeIdent, rt.typeIdent).map(_.id).contains("int")
+
+    if isInt then ShaderAST.Infix("%", lhs, rhs, rt)
+    else
+      ShaderAST.CallFunction(
+        "mod",
+        List(lhs, rhs),
+        rt
+      )
 
   def walkTerm(t: Term, envVarName: Option[String]): ShaderAST =
     t match
@@ -1266,6 +1308,9 @@ class CreateShaderAST[Q <: Quotes](using val qq: Q) extends ShaderMacroUtils:
             val lhs = walkTerm(term, envVarName)
             val rhs = xs.headOption.map(tt => walkTerm(tt, envVarName)).getOrElse(ShaderAST.Empty())
             val rt  = findReturnType(lhs)
+
+            checkOperandTypes(op, term, xs.headOption)
+
             ShaderAST.Infix(op, lhs, rhs, rt)
 
           case "&&" | "||" =>
@@ -1276,19 +1321,7 @@ class CreateShaderAST[Q <: Quotes](using val qq: Q) extends ShaderMacroUtils:
             ShaderAST.Infix(op, lhs, rhs, rt)
 
           case "%" =>
-            val lhs = walkTerm(term, envVarName)
-            val rhs = xs.headOption.map(tt => walkTerm(tt, envVarName)).getOrElse(ShaderAST.Empty())
-            val rt  = findReturnType(lhs)
-
-            val isInt = List(lhs.typeIdent, rhs.typeIdent, rt.typeIdent).map(_.id).contains("int")
-
-            if isInt then ShaderAST.Infix("%", lhs, rhs, rt)
-            else
-              ShaderAST.CallFunction(
-                "mod",
-                List(lhs, rhs),
-                rt
-              )
+            walkModulus(term, xs.headOption, envVarName)
 
           case "<<" | ">>" | "&" | "^" | "|" =>
             // Bitwise ops
@@ -1365,6 +1398,9 @@ class CreateShaderAST[Q <: Quotes](using val qq: Q) extends ShaderMacroUtils:
             val lhs = walkTerm(l, envVarName)
             val rhs = walkTerm(r, envVarName)
             val rt  = findReturnType(lhs)
+
+            checkOperandTypes(op, l, Some(r))
+
             ShaderAST.Infix(op, lhs, rhs, rt)
 
           case "&&" | "||" =>
@@ -1375,19 +1411,7 @@ class CreateShaderAST[Q <: Quotes](using val qq: Q) extends ShaderMacroUtils:
             ShaderAST.Infix(op, lhs, rhs, rt)
 
           case "%" =>
-            val lhs = walkTerm(l, envVarName)
-            val rhs = walkTerm(r, envVarName)
-            val rt  = findReturnType(lhs)
-
-            val isInt = List(lhs.typeIdent, rhs.typeIdent, rt.typeIdent).map(_.id).contains("int")
-
-            if isInt then ShaderAST.Infix("%", lhs, rhs, rt)
-            else
-              ShaderAST.CallFunction(
-                "mod",
-                List(lhs, rhs),
-                rt
-              )
+            walkModulus(l, Some(r), envVarName)
 
           case "<<" | ">>" | "&" | "^" | "|" =>
             // Bitwise ops

--- a/ultraviolet/src/ultraviolet/macros/ShaderMacroUtils.scala
+++ b/ultraviolet/src/ultraviolet/macros/ShaderMacroUtils.scala
@@ -9,6 +9,20 @@ trait ShaderMacroUtils:
   val isSwizzleable                             = "^(vec2|vec3|vec4|bvec2|bvec3|bvec4|ivec2|ivec3|ivec4)$".r
   def isGLSLReservedWord(word: String): Boolean = allReservedWords.contains(word)
 
+  val intTypes: Set[String]   = Set("int", "ivec2", "ivec3", "ivec4")
+  val floatTypes: Set[String] = Set("float", "vec2", "vec3", "vec4", "mat2", "mat3", "mat4")
+
+  /** GLSL has no implicit conversion between integer and floating point types, so an operator with one of each can
+    * never be translated. Types we do not model - anything that isn't in the two sets above - are left alone.
+    */
+  def isMixedNumericOperands(lhsType: String, rhsType: String): Boolean =
+    (intTypes.contains(lhsType) && floatTypes.contains(rhsType)) ||
+      (floatTypes.contains(lhsType) && intTypes.contains(rhsType))
+
+  def mixedNumericOperandsMsg(op: String, lhsType: String, rhsType: String): String =
+    s"Shaders do not support mixing integer and floating point types, found '$lhsType $op $rhsType'. " +
+      "GLSL requires both operands to share a base type, so please cast one of them, e.g. 'a.toFloat * b'."
+
   def findReturnType: ShaderAST => ShaderAST =
     case v: ShaderAST.Empty  => ShaderAST.void
     case v: ShaderAST.Block  => v.statements.reverse.headOption.map(findReturnType).getOrElse(ShaderAST.void)

--- a/ultraviolet/test/src/ultraviolet/acceptance/GLSLCastingTests.scala
+++ b/ultraviolet/test/src/ultraviolet/acceptance/GLSLCastingTests.scala
@@ -17,7 +17,7 @@ class GLSLCastingTests extends munit.FunSuite {
         val zz = y.toInt
         val w1 = 2
         val w2 = (1 + w1).toFloat
-        x + y
+        x.toFloat + y
       }
 
     val actual =
@@ -34,7 +34,7 @@ class GLSLCastingTests extends munit.FunSuite {
       |int zz=int(y);
       |int w1=2;
       |float w2=float(1+w1);
-      |x+y;
+      |float(x)+y;
       |""".stripMargin.trim
     )
   }

--- a/ultraviolet/test/src/ultraviolet/acceptance/GLSLOpsTests.scala
+++ b/ultraviolet/test/src/ultraviolet/acceptance/GLSLOpsTests.scala
@@ -64,6 +64,243 @@ class GLSLOpsTests extends munit.FunSuite {
     )
   }
 
+  test("Will retain % for Int variables") {
+
+    inline def fragment =
+      Shader {
+        def main: Unit =
+          val a      = 7
+          val b      = 3
+          val result = a % b
+      }
+
+    val actual =
+      fragment.toGLSL300.code
+
+    // DebugAST.toAST(fragment)
+    // println(actual)
+
+    assertNoDiff(
+      actual,
+      s"""
+      |void main(){
+      |  int a=7;
+      |  int b=3;
+      |  int result=a%b;
+      |}
+      |""".stripMargin.trim
+    )
+  }
+
+  test("Will retain % when only one side is an Int variable") {
+
+    inline def fragment =
+      Shader {
+        def main: Unit =
+          val a = 7
+          val b = 3
+          val x = a % 3
+          val y = 7 % b
+      }
+
+    val actual =
+      fragment.toGLSL300.code
+
+    // DebugAST.toAST(fragment)
+    // println(actual)
+
+    assertNoDiff(
+      actual,
+      s"""
+      |void main(){
+      |  int a=7;
+      |  int b=3;
+      |  int x=a%3;
+      |  int y=7%b;
+      |}
+      |""".stripMargin.trim
+    )
+  }
+
+  test("Will retain % for Int function arguments") {
+
+    inline def fragment =
+      Shader {
+        def wrap(a: Int, b: Int): Int =
+          a % b
+      }
+
+    val actual =
+      fragment.toGLSL300.code
+
+    // DebugAST.toAST(fragment)
+    // println(actual)
+
+    assertNoDiff(
+      actual,
+      s"""
+      |int wrap(in int a,in int b){
+      |  return a%b;
+      |}
+      |""".stripMargin.trim
+    )
+  }
+
+  test("Will retain % for Int array elements") {
+
+    inline def fragment =
+      Shader {
+        def main: Unit =
+          val arr: array[4, Int] = array[4, Int](7, 3, 2, 1)
+          val result             = arr(0) % arr(1)
+      }
+
+    val actual =
+      fragment.toGLSL300.code
+
+    // DebugAST.toAST(fragment)
+    // println(actual)
+
+    assertNoDiff(
+      actual,
+      s"""
+      |void main(){
+      |  int arr[4]=int[4](7,3,2,1);
+      |  int result=arr[0]%arr[1];
+      |}
+      |""".stripMargin.trim
+    )
+  }
+
+  test("Will retain % for Int types in %= assignments") {
+
+    @SuppressWarnings(Array("scalafix:DisableSyntax.var"))
+    inline def fragment =
+      Shader {
+        def main: Unit =
+          val j = 3
+          var i = 10
+          i %= j
+          val k = i
+      }
+
+    val actual =
+      fragment.toGLSL300.code
+
+    // DebugAST.toAST(fragment)
+    // println(actual)
+
+    assertNoDiff(
+      actual,
+      s"""
+      |void main(){
+      |  int j=3;
+      |  int i=10;
+      |  i=i%j;
+      |  int k=i;
+      |}
+      |""".stripMargin.trim
+    )
+  }
+
+  test("Will convert % to mod() for Float variables") {
+
+    inline def fragment =
+      Shader {
+        def main: Unit =
+          val x = 10.0f
+          val y = 2.0f
+          val z = x % y
+      }
+
+    val actual =
+      fragment.toGLSL300.code
+
+    // DebugAST.toAST(fragment)
+    // println(actual)
+
+    assertNoDiff(
+      actual,
+      s"""
+      |void main(){
+      |  float x=10.0;
+      |  float y=2.0;
+      |  float z=mod(x,y);
+      |}
+      |""".stripMargin.trim
+    )
+  }
+
+  test("GLSL 100 expands integer % to a-(b*(a/b))") {
+
+    inline def fragment =
+      Shader {
+        def main: Unit =
+          val a      = 7
+          val b      = 3
+          val result = a % b
+      }
+
+    val actual =
+      fragment.toGLSL100.code
+
+    // DebugAST.toAST(fragment)
+    // println(actual)
+
+    assertNoDiff(
+      actual,
+      s"""
+      |void main(){
+      |  int a=7;
+      |  int b=3;
+      |  int result=a-(b*(a/b));
+      |}
+      |""".stripMargin.trim
+    )
+  }
+
+  test("Mixing Int and Float operands is a compile error") {
+
+    val errors =
+      compileErrors(
+        """{
+  inline def fragment =
+    Shader {
+      def main: Unit =
+        val a = 7
+        val b = 2.0f
+        val c = a % b
+    }
+
+  fragment.toGLSL300.code
+}"""
+      )
+
+    assert(errors.contains("Shaders do not support mixing integer and floating point types"), errors)
+    assert(errors.contains("'int % float'"), errors)
+  }
+
+  test("Mixing Int and Float operands in math operators is a compile error") {
+
+    val errors =
+      compileErrors(
+        """{
+  inline def fragment =
+    Shader {
+      def main: Unit =
+        val a = 2.0f
+        val b = 7
+        val c = a * b
+    }
+
+  fragment.toGLSL300.code
+}"""
+      )
+
+    assert(errors.contains("Shaders do not support mixing integer and floating point types"), errors)
+    assert(errors.contains("'float * int'"), errors)
+  }
+
   test("clamp vec3 will accept float gentypes") {
 
     inline def fragment =

--- a/ultraviolet/test/src/ultraviolet/datatypes/ShaderTests.scala
+++ b/ultraviolet/test/src/ultraviolet/datatypes/ShaderTests.scala
@@ -208,7 +208,7 @@ class ShaderTests extends munit.FunSuite {
     case class UBO1(UV: vec2)
 
     inline def f: vec4 => Float  = _.x
-    inline def g: Float => Float = _ * 20
+    inline def g: Float => Float = _ * 20.0f
 
     inline def shader: Shader[UBO1, Float] =
       Shader[UBO1, vec4] { env =>
@@ -237,7 +237,7 @@ class ShaderTests extends munit.FunSuite {
       actualCode,
       s"""
       |float def1(in float val0){
-      |  return val0*20;
+      |  return val0*20.0;
       |}
       |float def2(in vec4 val1){
       |  return val1.x;

--- a/ultraviolet/test/src/ultraviolet/macros/ShaderMacroUtilsTests.scala
+++ b/ultraviolet/test/src/ultraviolet/macros/ShaderMacroUtilsTests.scala
@@ -1,0 +1,37 @@
+package ultraviolet.macros
+
+class ShaderMacroUtilsTests extends munit.FunSuite with ShaderMacroUtils {
+
+  test("isMixedNumericOperands - int and float families cannot be mixed") {
+    assert(isMixedNumericOperands("int", "float"))
+    assert(isMixedNumericOperands("float", "int"))
+    assert(isMixedNumericOperands("ivec2", "float"))
+    assert(isMixedNumericOperands("vec3", "int"))
+    assert(isMixedNumericOperands("ivec2", "mat2"))
+    assert(isMixedNumericOperands("mat4", "ivec4"))
+  }
+
+  test("isMixedNumericOperands - matching families are fine") {
+    assert(!isMixedNumericOperands("int", "int"))
+    assert(!isMixedNumericOperands("ivec2", "int"))
+    assert(!isMixedNumericOperands("float", "float"))
+    assert(!isMixedNumericOperands("vec3", "float"))
+    assert(!isMixedNumericOperands("mat4", "vec4"))
+  }
+
+  test("isMixedNumericOperands - types we do not model are left alone") {
+    assert(!isMixedNumericOperands("void", "float"))
+    assert(!isMixedNumericOperands("int", "void"))
+    assert(!isMixedNumericOperands("MyStruct", "int"))
+    assert(!isMixedNumericOperands("bool", "float"))
+    assert(!isMixedNumericOperands("sampler2D", "int"))
+  }
+
+  test("mixedNumericOperandsMsg names the operator and both types") {
+    val actual = mixedNumericOperandsMsg("%", "int", "float")
+
+    assert(actual.contains("'int % float'"), actual)
+    assert(actual.contains("toFloat"), actual)
+  }
+
+}


### PR DESCRIPTION
Relates to https://github.com/PurpleKingdomGames/indigoengine/issues/278

This started with the issue mentioned, which turned out to be slightly inaccurate: There was an attempt to rewrite correctly as % or mod, but it failed because it was checking the wrong value.

Other improvements where then made, specifically around catching invalid type combinations for mod operations at compile time.